### PR TITLE
Command line parameters! and some other improvements

### DIFF
--- a/cryptmypi.sh
+++ b/cryptmypi.sh
@@ -31,13 +31,20 @@ restore_output(){
 ############################
 # Verifying input parameters
 ############################
+# Default input variable value
+_OUTPUT_TO_FILE=""
+_STAGE1_CONFIRM=true
+_STAGE2_CONFIRM=true
+_BLKDEV_OVERRIDE=""
+
 # Check if configuration name was provided
 if [ -z "$1" ]; then
     echo "No argument supplied. Desired configuration folder should be supplied."
 fi
 _OUTPUT_TO_FILE=""
-_STAGE1_CONFIRM=false
-_STAGE2_CONFIRM=false
+_STAGE1_CONFIRM=true
+_STAGE2_CONFIRM=true
+_BLKDEV_OVERRIDE=""
 
 
 # Parameter/Option Variables
@@ -91,6 +98,10 @@ fi
 
 # Load configuration file
 . ${_CONFDIR}/cryptmypi.conf
+
+
+# Overriding _BLKDEV if _BLKDEV_OVERRIDE set
+[ -z "${_BLKDEV_OVERRIDE}" ] || _BLKDEV=${_BLKDEV_OVERRIDE}
 
 
 # Configuration dependent variables

--- a/cryptmypi.sh
+++ b/cryptmypi.sh
@@ -20,12 +20,23 @@ if [ -z "$1" ]; then
 fi
 
 
+# Determining script directory (absolute path resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+_SCRIPT_DIRECTORY="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+
+
 # Variables
 export _USER_HOME=$(eval echo ~${SUDO_USER})
 export _CONFDIRNAME=$1
 export _VER="4.0-beta"
-export _BASEDIR=$(pwd)
-export _CONFDIR=${_BASEDIR}/${_CONFDIRNAME}
+export _BASEDIR="${_SCRIPT_DIRECTORY}"
+export _CURRDIR=$(pwd)
+export _CONFDIR=${_CURRDIR}/${_CONFDIRNAME}
 export _BUILDDIR=${_CONFDIR}/build
 export _FILESDIR=${_BASEDIR}/files
 export _IMAGEDIR=${_FILESDIR}/images

--- a/cryptmypi.sh
+++ b/cryptmypi.sh
@@ -35,7 +35,9 @@ restore_output(){
 if [ -z "$1" ]; then
     echo "No argument supplied. Desired configuration folder should be supplied."
 fi
-_OUTPUT_TO_FILE="output"
+_OUTPUT_TO_FILE=""
+_STAGE1_CONFIRM=false
+_STAGE2_CONFIRM=false
 
 
 # Parameter/Option Variables
@@ -205,9 +207,11 @@ Cryptmypi will attempt to perform the following operations on the sdcard:
 
 EOF
 
-    read -p "Press enter to continue."
+    local _CONTINUE
+    $_STAGE2_CONFIRM && {
+        read -p "Press enter to continue."
 
-    cat << EOF
+        cat << EOF
 
 ##################### W A R N I N G #####################
 This process can damage your local install if the script
@@ -237,8 +241,14 @@ config directory.
 To continue type in the phrase 'Yes, do as I say!'
 EOF
 
-    echo -n ": "
-    read _CONTINUE
+        echo -n ": "
+        read _CONTINUE
+    } || {
+        echo "STAGE2 confirmation set to FALSE: skipping confirmation"
+        echo "STAGE2 will execute (assuming 'Yes, do as I say!' input) ..."
+        _CONTINUE='Yes, do as I say!'
+    }
+
     redirect_output
     case "${_CONTINUE}" in
         'Yes, do as I say!')
@@ -305,12 +315,20 @@ main(){
     else
         restore_output
         echo "Build directory already exists: ${_BUILDDIR}"
-        echo "Rebuild? (y/N)"
-        read _CONTINUE
-        _CONTINUE=`echo "${_CONTINUE}" | sed -e 's/\(.*\)/\L\1/'`
+
+        local _CONTINUE
+        $_STAGE1_CONFIRM && {
+            echo "Rebuild? (y/N)"
+            read _CONTINUE
+            _CONTINUE=`echo "${_CONTINUE}" | sed -e 's/\(.*\)/\L\1/'`
+        } || {
+            echo "STAGE1 confirmation set to FALSE: skipping confirmation"
+            echo "STAGE1 will be rebuilt ..."
+            _CONTINUE='y'
+        }
+
         redirect_output
         echo ""
-
         case "${_CONTINUE}" in
             'y')
                 echo "Removing current build files..."

--- a/cryptmypi.sh
+++ b/cryptmypi.sh
@@ -328,28 +328,36 @@ main(){
         echo "Build directory already exists: ${_BUILDDIR}"
 
         local _CONTINUE
-        $_STAGE1_CONFIRM && {
-            echo "Rebuild? (y/N)"
-            read _CONTINUE
-            _CONTINUE=`echo "${_CONTINUE}" | sed -e 's/\(.*\)/\L\1/'`
-        } || {
-            echo "STAGE1 confirmation set to FALSE: skipping confirmation"
-            echo "STAGE1 will be rebuilt ..."
-            _CONTINUE='y'
-        }
+        while true
+        do
+            $_STAGE1_CONFIRM && {
+                echo "Rebuild? (y/N)"
+                read _CONTINUE
+                _CONTINUE=`echo "${_CONTINUE}" | sed -e 's/\(.*\)/\L\1/'`
+            } || {
+                echo "STAGE1 confirmation set to FALSE: skipping confirmation"
+                echo "STAGE1 will be rebuilt ..."
+                _CONTINUE='y'
+            }
 
-        redirect_output
-        echo ""
-        case "${_CONTINUE}" in
-            'y')
-                echo "Removing current build files..."
-                rm -Rf ${_BUILDDIR}
-                execute "both"
-                ;;
-            *)
-                execute "stage2"
-                ;;
-        esac
+            redirect_output
+            echo ""
+            case "${_CONTINUE}" in
+                'y')
+                    echo "Removing current build files..."
+                    rm -Rf ${_BUILDDIR}
+                    execute "both"
+                    break;
+                    ;;
+                'n')
+                    execute "stage2"
+                    break;
+                    ;;
+                *)
+                    echo "Invalid input."
+                    ;;
+            esac
+        done
     fi
 }
 main

--- a/functions/hooks.fns
+++ b/functions/hooks.fns
@@ -8,7 +8,9 @@ myhooks(){
         do
             if [ -e ${_HOOK} ]; then
                 echo_info "- Calling $(basename ${_HOOK}) ..."
-                source ${_HOOK}
+                $_SIMULATE && {
+                    echo "SKIPPING: Simulation mode active: Hook will not be executed."
+                } || source ${_HOOK}
                 echo_info "    ... $(basename ${_HOOK}) completed!"
                 echo ""
             fi

--- a/hooks/0000-optional-sys-sshhub.hook
+++ b/hooks/0000-optional-sys-sshhub.hook
@@ -113,6 +113,7 @@ Host ${_SSHHUB_REFERENCE}-sys
     Port ${_SSHHUB_SSH_PORT}
     IdentityFile ${_SSH_LOCAL_KEYFILE}
     ProxyJump hub
+    ForwardAgent yes
 ${_ENTRYCOMMENT}-end
 EOT
 


### PR DESCRIPTION
## Script can now be executed from other directories (and using symlinks)

- The script can now be called from outside of its directory. 
- A symlink pointing to the script also can now be created (such as /usr/local/bin/cryptmypi)

## Fixed one of the user interactions

When asking if stage 1 shold be rebuilt, it would not handle invalid entries correctly.

## CLI parameters!!! (including --help)

```
OPTIONS:

    -d, --device <device>       Block device to use on stage 2
                                (overrides _BLKDEV configuration)

    --force-stage1, --rebuild   Overrides previous builds without confirmation
    --force-stage2              Writes to block device without confirmation
    --force-both-stages         Executes stage 1 and 2 without confirmation

    -s, --simulate              Simulate execution flow (does not call hooks)

    --options                   Display execution options
    -h, --help                  Display this help and exit
    -o,--output <file>          Redirects stdout and stderr to <file>
```