### PR TITLE
Changed the hardcoded device paths in 2400-stage1-setup-encryption.ho…

### DIFF
--- a/examples/pios-encrypted-basic-dropbear-v8+-usb/cryptmypi.conf
+++ b/examples/pios-encrypted-basic-dropbear-v8+-usb/cryptmypi.conf
@@ -1,0 +1,95 @@
+###############################################################################
+## cryptmypi profile ##########################################################
+
+
+# EXAMPLE OF A SIMPLE ENCRYPTED Raspberry Pi OS CONFIGURATION
+#   Will create a encrypted pios system:
+#   - during boot the encryption password will be prompted
+#   - with ssh server (available after boot)
+#       The id_rsa.pub public key will be added to authorized_keys
+#
+#   Some optional hooks are defined on stage2:
+#   - "optional-sys-rootpassword" that sets root password
+
+
+# General settings ------------------------------------------------------------
+# You need to choose a kernel compatible with your RPi version.
+#   - Re4son+ is for armv6 devices (ie. RPi1, RPi0, and RPi0w)
+#   - v7+ and v8+ sufixes are for the 32bit and 64bit armv7 devices (ie. RPi 3)
+#   - l+ sufix in the name means they will be ready for the RPi4.
+export _KERNEL_VERSION_FILTER="v8+"
+
+# HOSTNAME
+#   Each element of the hostname must be from 1 to 63 characters long and
+#   the entire hostname, including the dots, can be at most 253
+#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   from a to z, the digits from 0 to 9, and the hyphen (-)
+export _HOSTNAME="pios-encrypted-basic-dropbear-v8+-usb"
+# BLOCK DEVICE
+#   The SD card or USD SD card reader block device
+#   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
+#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
+#   You can use the lsblk command to get an easy quick view of all block
+#   devices on your system at a given moment.
+export _BLKDEV="/dev/sdc"
+
+
+# LUKS ENCRYPTION -------------------------------------------------------------
+## Encryption Cypher
+export _LUKSCIPHER="aes-cbc-essiv:sha256"
+
+## Encryption Password
+export _LUKSPASSWD="luks_password"
+
+
+# LINUX IMAGE FILE ------------------------------------------------------------
+export _IMAGEURL=https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2020-08-24/2020-08-20-raspios-buster-arm64-lite.zip
+# PACKAGE ACTIONS -------------------------------------------------------------
+export _PKGSPURGE=""
+export _PKGSINSTALL="tree htop"
+
+
+# MINIMAL SSH CONFIG ----------------------------------------------------------
+#   Keyfile to be used to access the system remotelly through ssh.
+#   Its public key will be added to the system's root .ssh/autorized_keys
+export _SSH_LOCAL_KEYFILE="$_USER_HOME/.ssh/id_rsa"
+
+
+###############################################################################
+## Stage 1 Settings ###########################################################
+
+# Custom Stage1 Profile
+#   Check functions/stage1profiles.fns for reference. You may instruct hooks
+#   here or you may call one predefined stage1profile functions.
+#   Optional function:
+#   - if stage1_hooks is not defined, you will be prompted
+#   - declare it if you want to skip script prompt predefining it
+stage1_hooks(){
+    stage1profile_complete
+}
+
+###############################################################################
+## Stage-2 Settings ###########################################################
+
+# Optional stage 2 hooks
+#   If declared, this function is called during stage2 build by the
+#   stage2-runoptional hook.
+#
+#   Optional function: can be ommited.
+stage2_optional_hooks(){
+    myhooks "optional-sys-rootpassword"
+}
+
+
+###############################################################################
+##Optional Hook Settings #####################################################
+
+
+# ROOT PASSWORD CHANGER settings ----------------------------------------------
+# Hooks
+#   optional-sys-rootpassword
+#       Changes the system root password
+
+## The new root password
+export _ROOTPASSWD="root_password"

--- a/examples/pios-encrypted-basic-dropbear-v8+-usb/setup.sh
+++ b/examples/pios-encrypted-basic-dropbear-v8+-usb/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+###################################
+# Raspbian Pi OS setup.sh
+
+echo 'Modifying /boot/cmdline.txt for encrypted boot.'
+sed -i.bak "s#quiet init=/usr/lib/raspi-config/init_resize.sh##g" /boot/cmdline.txt
+sed -i.bak "s#root=PARTUUID=.*-02#root=/dev/mapper/crypt cryptdevice=/dev/sda2:crypt#g" /boot/cmdline.txt
+
+echo 'Updating partition information in /etc/fstab for enctyped boot.'
+sed -i.bak "s#PARTUUID=.*-0#/dev/sda#g" /etc/fstab
+sed -i 's#/dev/sda2#/dev/mapper/crypt#g' /etc/fstab
+
+echo 'Enabling ssh on boot'
+touch /boot/ssh

--- a/hooks/2400-stage1-setup-encryption.hook
+++ b/hooks/2400-stage1-setup-encryption.hook
@@ -28,7 +28,7 @@ sed -i 's#/dev/mmcblk0p2#/dev/mapper/crypt#g' ${_BUILDDIR}/root/etc/fstab
 sed -i 's#ext3#ext4#g' ${_BUILDDIR}/root/etc/fstab
 
 # Update /etc/crypttab
-echo "crypt    /dev/mmcblk0p2    none    luks" > ${_BUILDDIR}/root/etc/crypttab
+echo "crypt    /dev/sda2    none    luks" > ${_BUILDDIR}/root/etc/crypttab
 
 # Create a hook to include our crypttab in the initramfs
 cat << EOF > ${_BUILDDIR}/root/etc/initramfs-tools/hooks/zz-cryptsetup
@@ -67,7 +67,7 @@ export PATH='/sbin:/bin/:/usr/sbin:/usr/bin'
 
 while true
 do
-    test -e /dev/mapper/crypt && break || cryptsetup luksOpen /dev/mmcblk0p2 crypt
+    test -e /dev/mapper/crypt && break || cryptsetup luksOpen /dev/sda2 crypt
 done
 
 /scripts/local-top/cryptroot


### PR DESCRIPTION
Hello,
I experimented a little with your project during the past week and tried to enable building an encrypted pios on a RPi4 that boots from USB. I actually managed to get this to work and it turned out to be quite easy, requiring only minimal changes in your code.

To get there I had to make a small adjustment to the hardcoded paths in 2400-stage1-setup-encryption.hook. Specifically in /etc/crypttab the device path needs to be changed from /dev/mmcblk0p2 to /dev/sda2.
The rest can be achieved via the configuration folder by using a setup.sh. I also included this in the example configuration: examples/pios-encrypted-basic-dropbear-v8+-usb
This build configuration is tested on the latest RPi4 8 GB.

I was unsure how to integrate this properly with your code and don't want to trample in your garden so I decided to just provide the working example on a separate branch and leave it up to you how to integrate this.

Edit: I forgot to add that this requires the latest boot firmware. This can be updated by: sudo rpi-eeprom-update -a

Best regards 
Julian