### PR TITLE
Fix typos in *.conf, stage1-otherscript.sh, stage2-otherscript.sh, *.hook and README.md files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ A configuration profile defines 2 stages:
 2. The build is written to an SD card.
 
 Optional configuration hooks can be set in any of the stages:
-- Configurations applyed on stage 1 will be avaiable to the stage 2. Each time the script runs it will check if a stage 1 build is already present, and will ask if it should be used or if it should be rebuilt.
-- Stage 2 can be executed as many times as wanted without affecting stage's 1 build. Every configuration applyed in stage 2 will be applyed directly to the SD card.
+- Configurations applied on stage 1 will be available to the stage 2. Each time the script runs it will check if a stage 1 build is already present, and will ask if it should be used or if it should be rebuilt.
+- Stage 2 can be executed as many times as wanted without affecting stage 1's build. Every configuration applied in stage 2 will be applied directly to the SD card.
 
 ## Capabilities
 
-1. **FULL DISK ENCRYPTION**: Although the project can be used to setup an unencrypted RPi box, it is currently capable to setup a fully encrypted Kali, Pi OS, or Ubuntu Linux.
+1. **FULL DISK ENCRYPTION**: Although the project can be used to set up an unencrypted RPi box, it is currently capable to set up a fully encrypted Kali, Pi OS, or Ubuntu Linux.
 
 - unlockable remotely through dropbear's ssh;
 - served through ethernet or wifi;
@@ -29,7 +29,7 @@ Optional configuration hooks can be set in any of the stages:
 - bypass firewalls using IODINE;
 - and a nuke password can be set;
 
-2. **OPERATIONAL**: System optional hooks can assis in many commonly configurations.
+2. **OPERATIONAL**: System optional hooks can assist in many common configurations.
 
 - setting ondemand cpu governor to reduce battery usage;
 - wireless network / adaptors can be pre-configured;
@@ -41,7 +41,7 @@ Optional configuration hooks can be set in any of the stages:
 
 ## Scenarios
 
-Example configurations are provided in the the project examples directory.
+Example configurations are provided in the project examples directory.
 
 Each example outlines a possible configurations scenario, from building a standard kali to building an encrypted drop box RPi for remote control.
 
@@ -62,6 +62,6 @@ You can decrypt, mount and chroot an SD card by using the `explore` pre-configur
 
 $ `./cryptmypi.sh examples/explore configuration_profile_directory`
 
-There is an actual `explore` directory that contains an customized configuration profile. This profile overwrites the default stage1 and stage2 hooks so that no formatting, partitioning, etc is done. It reads another configuration profile and mounts an block device accordingly.
+There is an actual `explore` directory that contains a customized configuration profile. This profile overwrites the default stage1 and stage2 hooks so that no formatting, partitioning, etc. is done. It reads another configuration profile and mounts a block device accordingly.
 
-Aditionally, you can use this "hack" configuration for more than chrooting to bash. You may update existing systems by copying the `examples/explore` directory and changing `stage2_optional_hooks` to execute optional hooks or other commands.
+Additionally, you can use this "hack" configuration for more than chrooting to bash. You may update existing systems by copying the `examples/explore` directory and changing `stage2_optional_hooks` to execute optional hooks or other commands.

--- a/examples/debian-encrypted-basic-dropbear/cryptmypi.conf
+++ b/examples/debian-encrypted-basic-dropbear/cryptmypi.conf
@@ -24,14 +24,14 @@ export _KERNEL_VERSION_FILTER="arm64"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="debian-encrypted-basic-dropbear"
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.
@@ -39,7 +39,7 @@ export _BLKDEV="/dev/sdb"
 
 
 # LUKS ENCRYPTION -------------------------------------------------------------
-## Encryption Cypher
+## Encryption Cipher
 export _LUKSCIPHER="aes-cbc-essiv:sha256"
 
 ## Encryption Password
@@ -50,7 +50,7 @@ export _LUKSPASSWD="luks_password"
 export _NEWLUKSUUID="no"
 
 ## Encryption Extra
-# On rpi0-1-2-3 you may want to reduce the required memory to unlock
+# On RPi0-1-2-3 you may want to reduce the required memory to unlock
 #  _LUKSEXTRA="--pbkdf-memory 131072"
 export _LUKSEXTRA="--key-size 256"
 

--- a/examples/debian-encrypted-basic-dropbear/stage1-otherscript.sh
+++ b/examples/debian-encrypted-basic-dropbear/stage1-otherscript.sh
@@ -4,5 +4,5 @@
 # Debian encrypted stage1-otherscript.sh
 
 
-echo 'Updating partition information in /etc/fstab for enctyped boot.'
+echo 'Updating partition information in /etc/fstab for encrypted boot.'
 sed -i 's#LABEL=RASPIROOT#/dev/mapper/crypt#g' /etc/fstab

--- a/examples/debian-encrypted-basic-dropbear/stage2-otherscript.sh
+++ b/examples/debian-encrypted-basic-dropbear/stage2-otherscript.sh
@@ -4,7 +4,7 @@
 # Debian encrypted stage2-otherscript.sh
 
 
-# At the time of testing the Debian OS for rpi works on labels, so we attempt to match.
+# At the time of testing the Debian OS for RPi works on labels, so we attempt to match.
 echo 'Setting up partition labels for Debian OS.'
 dosfslabel ${_BLKDEV}1 RASPIFIRM
 
@@ -24,6 +24,6 @@ sed -i.bak "s#initramfs initramfs.gz followkernel##g" /boot/config.txt
 
 ## Move our kernel in place of the targets default kernel
 __DEBIAN_KERNEL="initrd.img-5.18.0-3-arm64"
-echo "Movinng our /boot/initramfs.gz to /boot/${__DEBIAN_KERNEL}."
+echo "Moving our /boot/initramfs.gz to /boot/${__DEBIAN_KERNEL}."
 mv "/boot/${__DEBIAN_KERNEL}" "/boot/${__DEBIAN_KERNEL}-oos"
 mv /boot/initramfs.gz "/boot/${__DEBIAN_KERNEL}"

--- a/examples/debian-unencrypted/cryptmypi.conf
+++ b/examples/debian-unencrypted/cryptmypi.conf
@@ -2,8 +2,8 @@
 ## cryptmypi profile ##########################################################
 
 
-# EXAMPLE OF A SIMPLE UNENCRYPTED Debian CONFIGURATION for rpi
-#   Will create a no-encrypted Debian system, accessible locally through ssh
+# EXAMPLE OF A SIMPLE UNENCRYPTED Debian CONFIGURATION for RPi
+#   Will create an unencrypted Debian system, accessible locally through ssh
 #   An optional hook on stage2 will configure the system root user password
 
 
@@ -19,15 +19,15 @@ export _KERNEL_VERSION_FILTER="arm64"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="debian-unencrypted"
 
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.

--- a/examples/debian-unencrypted/stage2-otherscript.sh
+++ b/examples/debian-unencrypted/stage2-otherscript.sh
@@ -4,7 +4,7 @@
 # Debian stage2-otherscript.sh
 
 
-# At the time of testing the Debian for rpi works on labels, so we attempt to match.
+# At the time of testing the Debian for RPi works on labels, so we attempt to match.
 echo 'Setting up partition labels for Debian.'
 dosfslabel ${_BLKDEV}1 RASPIFIRM
 e2label ${_BLKDEV}2 RASPIROOT
@@ -12,6 +12,6 @@ e2label ${_BLKDEV}2 RASPIROOT
 
 # Move our kernel in place of the targets default kernel
 __DEBIAN_KERNEL="initrd.img-5.18.0-3-arm64"
-echo "Movinng our /boot/initramfs.gz to /boot/${__DEBIAN_KERNEL}."
+echo "Moving our /boot/initramfs.gz to /boot/${__DEBIAN_KERNEL}."
 mv "/boot/${__DEBIAN_KERNEL}" "/boot/${__DEBIAN_KERNEL}-oos"
 mv /boot/initramfs.gz "/boot/${__DEBIAN_KERNEL}"

--- a/examples/kali-complete/cryptmypi.conf
+++ b/examples/kali-complete/cryptmypi.conf
@@ -2,7 +2,7 @@
 ## cryptmypi profile ##########################################################
 
 
-# EXAMPLE OF A ENCRYPTED KALI CONFIGURATION, USING ALL AVAILABLE OPTIONAL HOOKS
+# EXAMPLE OF AN ENCRYPTED KALI CONFIGURATION, USING ALL AVAILABLE OPTIONAL HOOKS
 #   Will create an encrypted Kali system:
 #   - "optional-sys-cpugovernor-ondemand" that changes the cpugovernor to
 #       on demand, especially useful when the RPi will run using batteries
@@ -28,7 +28,7 @@
 #   - "optional-sys-vpnclient" configures vpn
 #
 #   - IODINE hook is not enabled, but may work. Not tested, work may be needed
-#       on it, as initrafs and sys configs are not separated. It would tunnel
+#       on it, as initramfs and sys configs are not separated. It would tunnel
 #       traffic through DNS, bypassing most firewalls.
 
 
@@ -36,7 +36,7 @@
 # You need to choose a kernel compatible with your RPi version.
 #   Kali RPi images name its kernels:
 #   - Re4son+ is for armv6 devices (ie. RPi1, RPi0, and RPi0w)
-#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi 3)
+#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi3)
 #   - l+ is mostly for the RPi4 since one can have 4GB or 8GB versions
 #     The l in l+ actually means lpae (Large Physical Address Extensions)
 export _KERNEL_VERSION_FILTER="v8+"
@@ -44,14 +44,14 @@ export _KERNEL_VERSION_FILTER="v8+"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="kali-complete"
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.
@@ -59,7 +59,7 @@ export _BLKDEV="/dev/sdb"
 
 
 # LUKS ENCRYPTION -------------------------------------------------------------
-## Encryption Cypher
+## Encryption Cipher
 export _LUKSCIPHER="aes-cbc-essiv:sha256"
 
 ## Encryption Password
@@ -70,7 +70,7 @@ export _LUKSPASSWD="luks_password"
 export _NEWLUKSUUID="no"
 
 ## Encryption Extra
-# On rpi0-1-2-3 you may want to reduce the required memory to unlock
+# On RPi0-1-2-3 you may want to reduce the required memory to unlock
 #  _LUKSEXTRA="--pbkdf-memory 131072"
 export _LUKSEXTRA="--key-size 256"
 
@@ -160,7 +160,7 @@ export _LUKSNUKEPASSWD="luks_nuke_password"
 # IODINE settings -------------------------------------------------------------
 # Hooks
 #   untested-optional-initramfs-iodine
-#       Configures IODINE to allow DNS tunneling of dataat intrafs, so that
+#       Configures IODINE to allow DNS tunneling of data at initramfs, so that
 #       traffic is harder to be detected and firewalls can be bypassed.
 
 ## IODINE Domain
@@ -189,7 +189,7 @@ export _IODINE_PASSWORD=""
 # Optional variable (default: none)
 #export _SSHJUMP_LOCAL_KEYFILE="$_USER_HOME/.ssh/id_rsa"
 
-## PIs computer name to be used on sshjump
+## PI's computer name to be used on sshjump
 # Optional variable (default: _HOSTNAME)
 #export _SSHJUMP_COMPUTER=""
 
@@ -218,7 +218,7 @@ export _SSHHUB_USERNAME="the_user"
 # Optional variable (default: none)
 export _SSHHUB_LOCAL_KEYFILE="$_USER_HOME/.ssh/id_rsa"
 
-## PIs computer name to be used on sshhub.de
+## PI's computer name to be used on sshhub.de
 # Optional variable (default: _HOSTNAME)
 export _SSHHUB_COMPUTER=""
 

--- a/examples/kali-encrypted-basic-dropbear/cryptmypi.conf
+++ b/examples/kali-encrypted-basic-dropbear/cryptmypi.conf
@@ -2,7 +2,7 @@
 ## cryptmypi profile ##########################################################
 
 
-# EXAMPLE OF A ENCRYPTED KALI CONFIGURATION
+# EXAMPLE OF AN ENCRYPTED KALI CONFIGURATION
 #   Will create an encrypted Kali system:
 #   - during boot the encryption password will be prompted both
 #       via the console and ssh on port 2222
@@ -17,7 +17,7 @@
 # You need to choose a kernel compatible with your RPi version.
 #   Kali RPi images name its kernels:
 #   - Re4son+ is for armv6 devices (ie. RPi1, RPi0, and RPi0w)
-#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi 3)
+#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi3)
 #   - l+ is mostly for the RPi4 since one can have 4GB or 8GB versions
 #     The l in l+ actually means lpae (Large Physical Address Extensions)
 export _KERNEL_VERSION_FILTER="v8+"
@@ -25,21 +25,21 @@ export _KERNEL_VERSION_FILTER="v8+"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="kali-encrypted-basic-dropbear"
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.
 export _BLKDEV="/dev/sdb"
 
 # LUKS ENCRYPTION -------------------------------------------------------------
-## Encryption Cypher
+## Encryption Cipher
 export _LUKSCIPHER="aes-cbc-essiv:sha256"
 
 ## Encryption Password
@@ -50,7 +50,7 @@ export _LUKSPASSWD="luks_password"
 export _NEWLUKSUUID="no"
 
 ## Encryption Extra
-# On rpi0-1-2-3 you may want to reduce the required memory to unlock
+# On RPi0-1-2-3 you may want to reduce the required memory to unlock
 #  _LUKSEXTRA="--pbkdf-memory 131072"
 export _LUKSEXTRA="--key-size 256"
 

--- a/examples/kali-encrypted-basic-nuke/cryptmypi.conf
+++ b/examples/kali-encrypted-basic-nuke/cryptmypi.conf
@@ -2,7 +2,7 @@
 ## cryptmypi profile ##########################################################
 
 
-# EXAMPLE OF A ENCRYPTED KALI CONFIGURATION
+# EXAMPLE OF AN ENCRYPTED KALI CONFIGURATION
 #   Will create an encrypted Kali system:
 #   - during boot the encryption password will be prompted, including the
 #     ability to nuke the encrypted filesystem access with luks nuke password
@@ -17,7 +17,7 @@
 # You need to choose a kernel compatible with your RPi version.
 #   Kali RPi images name its kernels:
 #   - Re4son+ is for armv6 devices (ie. RPi1, RPi0, and RPi0w)
-#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi 3)
+#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi3)
 #   - l+ is mostly for the RPi4 since one can have 4GB or 8GB versions
 #     The l in l+ actually means lpae (Large Physical Address Extensions)
 export _KERNEL_VERSION_FILTER="v8+"
@@ -25,21 +25,21 @@ export _KERNEL_VERSION_FILTER="v8+"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="kali-encrypted-basic-nuke"
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.
 export _BLKDEV="/dev/sdb"
 
 # LUKS ENCRYPTION -------------------------------------------------------------
-## Encryption Cypher
+## Encryption Cipher
 export _LUKSCIPHER="aes-cbc-essiv:sha256"
 
 ## Encryption Password
@@ -50,7 +50,7 @@ export _LUKSPASSWD="luks_password"
 export _NEWLUKSUUID="no"
 
 ## Encryption Extra
-# On rpi0-1-2-3 you may want to reduce the required memory to unlock
+# On RPi0-1-2-3 you may want to reduce the required memory to unlock
 #  _LUKSEXTRA="--pbkdf-memory 131072"
 export _LUKSEXTRA="--key-size 256"
 

--- a/examples/kali-encrypted-basic/cryptmypi.conf
+++ b/examples/kali-encrypted-basic/cryptmypi.conf
@@ -2,7 +2,7 @@
 ## cryptmypi profile ##########################################################
 
 
-# EXAMPLE OF A ENCRYPTED KALI CONFIGURATION
+# EXAMPLE OF AN ENCRYPTED KALI CONFIGURATION
 #   Will create an encrypted Kali system:
 #   - during boot the encryption password will be prompted
 #   - with ssh server (available after boot)
@@ -16,7 +16,7 @@
 # You need to choose a kernel compatible with your RPi version.
 #   Kali RPi images name its kernels:
 #   - Re4son+ is for armv6 devices (ie. RPi1, RPi0, and RPi0w)
-#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi 3)
+#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi3)
 #   - l+ is mostly for the RPi4 since one can have 4GB or 8GB versions
 #     The l in l+ actually means lpae (Large Physical Address Extensions)
 export _KERNEL_VERSION_FILTER="v8+"
@@ -24,21 +24,21 @@ export _KERNEL_VERSION_FILTER="v8+"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="kali-encrypted-basic"
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.
 export _BLKDEV="/dev/sdb"
 
 # LUKS ENCRYPTION -------------------------------------------------------------
-## Encryption Cypher
+## Encryption Cipher
 export _LUKSCIPHER="aes-cbc-essiv:sha256"
 
 ## Encryption Password
@@ -49,7 +49,7 @@ export _LUKSPASSWD="luks_password"
 export _NEWLUKSUUID="no"
 
 ## Encryption Extra
-# On rpi0-1-2-3 you may want to reduce the required memory to unlock
+# On RPi0-1-2-3 you may want to reduce the required memory to unlock
 #  _LUKSEXTRA="--pbkdf-memory 131072"
 export _LUKSEXTRA="--key-size 256"
 

--- a/examples/kali-encrypted-docker-tor-irssi/cryptmypi.conf
+++ b/examples/kali-encrypted-docker-tor-irssi/cryptmypi.conf
@@ -2,7 +2,7 @@
 ## cryptmypi profile ##########################################################
 
 
-# EXAMPLE OF A ENCRYPTED KALI CONFIGURATION WITH SSH ACCESS (dropbear and sshd)
+# EXAMPLE OF AN ENCRYPTED KALI CONFIGURATION WITH SSH ACCESS (dropbear and sshd)
 # THAT IS PRE-CONFIGURED A DOCKER CONTAINER ACCESSIBLE THROUGH tor-irssi COMMAND
 #
 #   Will create an encrypted Kali system:
@@ -24,7 +24,7 @@
 # You need to choose a kernel compatible with your RPi version.
 #   Kali RPi images name its kernels:
 #   - Re4son+ is for armv6 devices (ie. RPi1, RPi0, and RPi0w)
-#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi 3)
+#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi3)
 #   - l+ is mostly for the RPi4 since one can have 4GB or 8GB versions
 #     The l in l+ actually means lpae (Large Physical Address Extensions)
 export _KERNEL_VERSION_FILTER="v8+"
@@ -33,15 +33,15 @@ export _KERNEL_VERSION_FILTER="v8+"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="kali-encrypted-docker-tor-irssi"
 
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.
@@ -49,7 +49,7 @@ export _BLKDEV="/dev/mmcblk0"
 
 
 # LUKS ENCRYPTION -------------------------------------------------------------
-## Encryption Cypher
+## Encryption Cipher
 export _LUKSCIPHER="aes-cbc-essiv:sha256"
 
 ## Encryption Password
@@ -60,7 +60,7 @@ export _LUKSPASSWD="luks_password"
 export _NEWLUKSUUID="no"
 
 ## Encryption Extra
-# On rpi0-1-2-3 you may want to reduce the required memory to unlock
+# On RPi0-1-2-3 you may want to reduce the required memory to unlock
 #  _LUKSEXTRA="--pbkdf-memory 131072"
 export _LUKSEXTRA="--key-size 256"
 

--- a/examples/kali-encrypted-docker-tor-irssi/stage1-otherscript.sh
+++ b/examples/kali-encrypted-docker-tor-irssi/stage1-otherscript.sh
@@ -33,7 +33,7 @@ echo "CREATING IRSSI BASIC CONFIG FILES"
 cd ~
 mkdir -p .irssi
 
-# Place your .irssi config bellow (this is only an minimal example file)
+# Place your .irssi config below (this is only a minimal example file)
 cat <<EOF > ~/.irssi/config
 servers = (
   {
@@ -171,7 +171,7 @@ EOF
 
 
 mkdir -p .irssi/certs
-# Place your certificate bellow (substitute the invalid example)
+# Place your certificate below (substitute the invalid example)
 cat <<'EOF' > ~/.irssi/certs/FreenodeTor.pem
 
             !!!!!!IMPORTANT!!!!!!

--- a/examples/kali-encrypted-sshhub/cryptmypi.conf
+++ b/examples/kali-encrypted-sshhub/cryptmypi.conf
@@ -2,7 +2,7 @@
 ## cryptmypi profile ##########################################################
 
 
-# EXAMPLE OF A ENCRYPTED KALI CONFIGURATION
+# EXAMPLE OF AN ENCRYPTED KALI CONFIGURATION
 #   Will create an encrypted Kali system:
 #   - during boot the encryption password will be prompted
 #   - 2 packages will be installed: tree and htop
@@ -11,8 +11,8 @@
 #
 #   Some optional hooks are defined on stage1:
 #   - "optional-sys-cpugovernor-ondemand" that changes the cpugovernor to
-#       ondemand, specially useful when the RPi will run using batteries
-#   - "optional-sys-dns" that pre-configures DNS to google (see vars bellow)
+#       on demand, especially useful when the RPi will run using batteries
+#   - "optional-sys-dns" that pre-configures DNS to google (see vars below)
 #   - "optional-sys-sshhub" that exposes the ssh server to the internet
 #       through sshhub.de using reverse ssh jumps, eliminating the need
 #       of router port forwarding
@@ -27,7 +27,7 @@
 # You need to choose a kernel compatible with your RPi version.
 #   Kali RPi images name its kernels:
 #   - Re4son+ is for armv6 devices (ie. RPi1, RPi0, and RPi0w)
-#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi 3)
+#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi3)
 #   - l+ is mostly for the RPi4 since one can have 4GB or 8GB versions
 #     The l in l+ actually means lpae (Large Physical Address Extensions)
 export _KERNEL_VERSION_FILTER="v8+"
@@ -35,14 +35,14 @@ export _KERNEL_VERSION_FILTER="v8+"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="kali-encrypted"
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.
@@ -50,7 +50,7 @@ export _BLKDEV="/dev/sdb"
 
 
 # LUKS ENCRYPTION -------------------------------------------------------------
-## Encryption Cypher
+## Encryption Cipher
 export _LUKSCIPHER="aes-cbc-essiv:sha256"
 
 ## Encryption Password
@@ -61,7 +61,7 @@ export _LUKSPASSWD="luks_password"
 export _NEWLUKSUUID="no"
 
 ## Encryption Extra
-# On rpi0-1-2-3 you may want to reduce the required memory to unlock
+# On RPi0-1-2-3 you may want to reduce the required memory to unlock
 #  _LUKSEXTRA="--pbkdf-memory 131072"
 export _LUKSEXTRA="--key-size 256"
 
@@ -141,7 +141,7 @@ export _SSHHUB_USERNAME="a_user"
 # Optional variable (default: none)
 export _SSHHUB_LOCAL_KEYFILE="$_USER_HOME/.ssh/id_rsa"
 
-## PIs computer name to be used on sshhub.de
+## PI's computer name to be used on sshhub.de
 # Optional variable (default: _HOSTNAME)
 export _SSHHUB_COMPUTER=""
 

--- a/examples/kali-unencrypted/cryptmypi.conf
+++ b/examples/kali-unencrypted/cryptmypi.conf
@@ -3,7 +3,7 @@
 
 
 # EXAMPLE OF A SIMPLE UNENCRYPTED KALI CONFIGURATION
-#   Will create a no-encrypted Kali system, accessible locally through ssh
+#   Will create an unencrypted Kali system, accessible locally through ssh
 #   An optional hook on stage2 will configure the system root user password
 
 
@@ -11,7 +11,7 @@
 # You need to choose a kernel compatible with your RPi version.
 #   Kali RPi images name its kernels:
 #   - Re4son+ is for armv6 devices (ie. RPi1, RPi0, and RPi0w)
-#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi 3)
+#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi3)
 #   - l+ is mostly for the RPi4 since one can have 4GB or 8GB versions
 #     The l in l+ actually means lpae (Large Physical Address Extensions)
 export _KERNEL_VERSION_FILTER="v8+"
@@ -19,14 +19,14 @@ export _KERNEL_VERSION_FILTER="v8+"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="kali-unencrypted"
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.

--- a/examples/pios-encrypted-basic-dropbear-arm64/cryptmypi.conf
+++ b/examples/pios-encrypted-basic-dropbear-arm64/cryptmypi.conf
@@ -16,7 +16,7 @@
 # General settings ------------------------------------------------------------
 # You need to choose a kernel compatible with your RPi version.
 #   - Re4son+ is for armv6 devices (ie. RPi1, RPi0, and RPi0w)
-#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi 3)
+#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi3)
 #   - l+ is mostly for the RPi4 since one can have 4GB or 8GB versions
 #     The l in l+ actually means lpae (Large Physical Address Extensions)
 export _KERNEL_VERSION_FILTER="v8+"
@@ -24,14 +24,14 @@ export _KERNEL_VERSION_FILTER="v8+"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="pios-encrypted-basic-dropbear-arm64"
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.
@@ -39,7 +39,7 @@ export _BLKDEV="/dev/sdb"
 
 
 # LUKS ENCRYPTION -------------------------------------------------------------
-## Encryption Cypher
+## Encryption Cipher
 export _LUKSCIPHER="aes-cbc-essiv:sha256"
 
 ## Encryption Password
@@ -50,7 +50,7 @@ export _LUKSPASSWD="luks_password"
 export _NEWLUKSUUID="no"
 
 ## Encryption Extra
-# On rpi0-1-2-3 you may want to reduce the required memory to unlock
+# On RPi0-1-2-3 you may want to reduce the required memory to unlock
 #  _LUKSEXTRA="--pbkdf-memory 131072"
 export _LUKSEXTRA="--key-size 256"
 

--- a/examples/pios-encrypted-basic-dropbear-arm64/stage1-otherscript.sh
+++ b/examples/pios-encrypted-basic-dropbear-arm64/stage1-otherscript.sh
@@ -7,7 +7,7 @@
 echo 'Modifying /boot/cmdline.txt for encrypted boot.'
 sed -i.bak -e "s#quiet init=/usr/lib/raspberrypi-sys-mods/firstboot##g" -e "s#root=PARTUUID=.*-02#root=/dev/mapper/crypt#g" /boot/cmdline.txt
 
-echo 'Updating partition information in /etc/fstab for enctyped boot.'
+echo 'Updating partition information in /etc/fstab for encrypted boot.'
 sed -i.bak "s#PARTUUID=.*-0#/dev/mmcblk0p#g" /etc/fstab
 sed -i 's#/dev/mmcblk0p2#/dev/mapper/crypt#g' /etc/fstab
 
@@ -21,4 +21,4 @@ touch /boot/ssh
 
 
 # Disable user creation prompt
-systemctl disable userconfig > /dev/null 2&>1
+systemctl disable userconfig > /dev/null 2>&1

--- a/examples/pios-encrypted-basic-dropbear/cryptmypi.conf
+++ b/examples/pios-encrypted-basic-dropbear/cryptmypi.conf
@@ -16,7 +16,7 @@
 # General settings ------------------------------------------------------------
 # You need to choose a kernel compatible with your RPi version.
 #   - Re4son+ is for armv6 devices (ie. RPi1, RPi0, and RPi0w)
-#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi 3)
+#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi3)
 #   - l+ is mostly for the RPi4 since one can have 4GB or 8GB versions
 #     The l in l+ actually means lpae (Large Physical Address Extensions)
 export _KERNEL_VERSION_FILTER="v7+"
@@ -24,14 +24,14 @@ export _KERNEL_VERSION_FILTER="v7+"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="pios-encrypted-basic-dropbear"
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.
@@ -39,7 +39,7 @@ export _BLKDEV="/dev/sdb"
 
 
 # LUKS ENCRYPTION -------------------------------------------------------------
-## Encryption Cypher
+## Encryption Cipher
 export _LUKSCIPHER="aes-cbc-essiv:sha256"
 
 ## Encryption Password
@@ -50,7 +50,7 @@ export _LUKSPASSWD="luks_password"
 export _NEWLUKSUUID="no"
 
 ## Encryption Extra
-# On rpi0-1-2-3 you may want to reduce the required memory to unlock
+# On RPi0-1-2-3 you may want to reduce the required memory to unlock
 #  _LUKSEXTRA="--pbkdf-memory 131072"
 export _LUKSEXTRA="--key-size 256"
 

--- a/examples/pios-encrypted-basic-dropbear/stage1-otherscript.sh
+++ b/examples/pios-encrypted-basic-dropbear/stage1-otherscript.sh
@@ -7,7 +7,7 @@
 echo 'Modifying /boot/cmdline.txt for encrypted boot.'
 sed -i.bak -e "s#quiet init=/usr/lib/raspberrypi-sys-mods/firstboot##g" -e "s#root=PARTUUID=.*-02#root=/dev/mapper/crypt#g" /boot/cmdline.txt
 
-echo 'Updating partition information in /etc/fstab for enctyped boot.'
+echo 'Updating partition information in /etc/fstab for encrypted boot.'
 sed -i.bak "s#PARTUUID=.*-0#/dev/mmcblk0p#g" /etc/fstab
 sed -i 's#/dev/mmcblk0p2#/dev/mapper/crypt#g' /etc/fstab
 
@@ -21,4 +21,4 @@ touch /boot/ssh
 
 
 # Disable user creation prompt
-systemctl disable userconfig > /dev/null 2&>1
+systemctl disable userconfig > /dev/null 2>&1

--- a/examples/pios-encrypted-basic/cryptmypi.conf
+++ b/examples/pios-encrypted-basic/cryptmypi.conf
@@ -15,7 +15,7 @@
 # General settings ------------------------------------------------------------
 # You need to choose a kernel compatible with your RPi version.
 #   - Re4son+ is for armv6 devices (ie. RPi1, RPi0, and RPi0w)
-#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi 3)
+#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi3)
 #   - l+ is mostly for the RPi4 since one can have 4GB or 8GB versions
 #     The l in l+ actually means lpae (Large Physical Address Extensions)
 export _KERNEL_VERSION_FILTER="v7+"
@@ -23,14 +23,14 @@ export _KERNEL_VERSION_FILTER="v7+"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="pios-encrypted-basic"
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.
@@ -38,7 +38,7 @@ export _BLKDEV="/dev/sdb"
 
 
 # LUKS ENCRYPTION -------------------------------------------------------------
-## Encryption Cypher
+## Encryption Cipher
 export _LUKSCIPHER="aes-cbc-essiv:sha256"
 
 ## Encryption Password
@@ -49,7 +49,7 @@ export _LUKSPASSWD="luks_password"
 export _NEWLUKSUUID="no"
 
 ## Encryption Extra
-# On rpi0-1-2-3 you may want to reduce the required memory to unlock
+# On RPi0-1-2-3 you may want to reduce the required memory to unlock
 #  _LUKSEXTRA="--pbkdf-memory 131072"
 export _LUKSEXTRA="--key-size 256"
 

--- a/examples/pios-encrypted-basic/stage1-otherscript.sh
+++ b/examples/pios-encrypted-basic/stage1-otherscript.sh
@@ -7,7 +7,7 @@
 echo 'Modifying /boot/cmdline.txt for encrypted boot.'
 sed -i.bak -e "s#quiet init=/usr/lib/raspberrypi-sys-mods/firstboot##g" -e "s#root=PARTUUID=.*-02#root=/dev/mapper/crypt#g" /boot/cmdline.txt
 
-echo 'Updating partition information in /etc/fstab for enctyped boot.'
+echo 'Updating partition information in /etc/fstab for encrypted boot.'
 sed -i.bak "s#PARTUUID=.*-0#/dev/mmcblk0p#g" /etc/fstab
 sed -i 's#/dev/mmcblk0p2#/dev/mapper/crypt#g' /etc/fstab
 
@@ -21,4 +21,4 @@ touch /boot/ssh
 
 
 # Disable user creation prompt
-systemctl disable userconfig > /dev/null 2&>1
+systemctl disable userconfig > /dev/null 2>&1

--- a/examples/pios-unencrypted/cryptmypi.conf
+++ b/examples/pios-unencrypted/cryptmypi.conf
@@ -3,14 +3,14 @@
 
 
 # EXAMPLE OF A SIMPLE UNENCRYPTED Raspberry Pi OS CONFIGURATION
-#   Will create a no-encrypted PiOS system, accessible locally through ssh
+#   Will create an unencrypted PiOS system, accessible locally through ssh
 #   An optional hook on stage2 will configure the system root user password
 
 
 # General settings ------------------------------------------------------------
 # You need to choose a kernel compatible with your RPi version.
 #   - Re4son+ is for armv6 devices (ie. RPi1, RPi0, and RPi0w)
-#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi 3)
+#   - v7+ and v8+ are for the 32bit and 64bit armv7 devices (ie. RPi3)
 #   - l+ is mostly for the RPi4 since one can have 4GB or 8GB versions
 #     The l in l+ actually means lpae (Large Physical Address Extensions)
 export _KERNEL_VERSION_FILTER="v7+"
@@ -18,14 +18,14 @@ export _KERNEL_VERSION_FILTER="v7+"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="pios-unencrypted"
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.

--- a/examples/pios-unencrypted/stage1-otherscript.sh
+++ b/examples/pios-unencrypted/stage1-otherscript.sh
@@ -20,4 +20,4 @@ touch /boot/ssh
 
 
 # Disable user creation prompt
-systemctl disable userconfig > /dev/null 2&>1
+systemctl disable userconfig > /dev/null 2>&1

--- a/examples/ubuntu-encrypted-basic/cryptmypi.conf
+++ b/examples/ubuntu-encrypted-basic/cryptmypi.conf
@@ -2,7 +2,7 @@
 ## cryptmypi profile ##########################################################
 
 
-# EXAMPLE OF A SIMPLE UNENCRYPTED Ubuntu CONFIGURATION for rpi
+# EXAMPLE OF A SIMPLE UNENCRYPTED Ubuntu CONFIGURATION for RPi
 #   Will create an encrypted Ubuntu system, accessible locally
 #   An optional hook on stage2 will configure the system root user password
 
@@ -15,15 +15,15 @@ export _KERNEL_VERSION_FILTER="raspi"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="ubuntu-encrypted-basic"
 
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.
@@ -31,7 +31,7 @@ export _BLKDEV="/dev/sdb"
 
 
 # LUKS ENCRYPTION -------------------------------------------------------------
-## Encryption Cypher
+## Encryption Cipher
 export _LUKSCIPHER="aes-cbc-essiv:sha256"
 
 ## Encryption Password
@@ -42,7 +42,7 @@ export _LUKSPASSWD="luks_password"
 export _NEWLUKSUUID="no"
 
 ## Encryption Extra
-# On rpi0-1-2-3 you may want to reduce the required memory to unlock
+# On RPi0-1-2-3 you may want to reduce the required memory to unlock
 #  _LUKSEXTRA="--pbkdf-memory 131072"
 export _LUKSEXTRA="--key-size 256"
 

--- a/examples/ubuntu-encrypted-basic/stage2-otherscript.sh
+++ b/examples/ubuntu-encrypted-basic/stage2-otherscript.sh
@@ -4,7 +4,7 @@
 # Ubuntu encrypted stage2-otherscript.sh
 
 
-# At the time of testing the Ubuntu for rpi works on labels, so we attempt to match.
+# At the time of testing the Ubuntu for RPi works on labels, so we attempt to match.
 echo 'Setting up partition labels for Ubuntu.'
 dosfslabel ${_BLKDEV}1 system-boot
 
@@ -18,13 +18,13 @@ echo 'Drop the initramfs entry we made in /boot/config.txt'
 sed -i.bak "s#initramfs initramfs.gz followkernel##g" /boot/config.txt
 
 
-echo 'Updating partition information in /etc/fstab for enctyped boot.'
+echo 'Updating partition information in /etc/fstab for encrypted boot.'
 sed -i 's#LABEL=writable#/dev/mapper/crypt#g' /etc/fstab
 
 
 # Move our kernel in place of the targets default kernel
 __UBUNTU_KERNEL="initrd.img-5.19.0-1004-raspi"
-echo "Movinng our /boot/initramfs.gz to /boot/${__UBUNTU_KERNEL}."
+echo "Moving our /boot/initramfs.gz to /boot/${__UBUNTU_KERNEL}."
 mv "/boot/${__UBUNTU_KERNEL}" "/boot/${__UBUNTU_KERNEL}-oos"
 cp /boot/initramfs.gz /boot/initrd.img
 mv /boot/initramfs.gz "/boot/${__UBUNTU_KERNEL}"

--- a/examples/ubuntu-unencrypted/cryptmypi.conf
+++ b/examples/ubuntu-unencrypted/cryptmypi.conf
@@ -2,8 +2,8 @@
 ## cryptmypi profile ##########################################################
 
 
-# EXAMPLE OF A SIMPLE UNENCRYPTED Ubuntu CONFIGURATION for rpi
-#   Will create a no-encrypted Ubuntu system, accessible locally through ssh
+# EXAMPLE OF A SIMPLE UNENCRYPTED Ubuntu CONFIGURATION for RPi
+#   Will create an unencrypted Ubuntu system, accessible locally through ssh
 #   An optional hook on stage2 will configure the system root user password
 
 
@@ -15,15 +15,15 @@ export _KERNEL_VERSION_FILTER="raspi"
 # HOSTNAME
 #   Each element of the hostname must be from 1 to 63 characters long and
 #   the entire hostname, including the dots, can be at most 253
-#   characters long.  Valid characters for hostnames are ASCII(7) letters
+#   characters long. Valid characters for hostnames are ASCII(7) letters
 #   from a to z, the digits from 0 to 9, and the hyphen (-)
 export _HOSTNAME="ubuntu-unencrypted"
 
 
 # BLOCK DEVICE
-#   The SD card or USD SD card reader block device
+#   The SD card or USB SD card reader block device
 #   - USB drives will show up as the normal /dev/sdb, /dev/sdc, etc.
-#   - MMC/SDcards may show up the same way if the card reader is USB-connected.
+#   - MMC/SD cards may show up the same way if the card reader is USB-connected.
 #   - Internal card readers normally show up as /dev/mmcblk0, /dev/mmcblk1, ...
 #   You can use the lsblk command to get an easy quick view of all block
 #   devices on your system at a given moment.

--- a/examples/ubuntu-unencrypted/stage2-otherscript.sh
+++ b/examples/ubuntu-unencrypted/stage2-otherscript.sh
@@ -4,7 +4,7 @@
 # Ubuntu stage2-otherscript.sh
 
 
-# At the time of testing the Ubuntu for rpi works on labels, so we attempt to match.
+# At the time of testing the Ubuntu for RPi works on labels, so we attempt to match.
 echo 'Setting up partition labels for Ubuntu.'
 dosfslabel ${_BLKDEV}1 system-boot
 e2label ${_BLKDEV}2 writable
@@ -12,7 +12,7 @@ e2label ${_BLKDEV}2 writable
 
 # Move our kernel in place of the targets default kernel
 __UBUNTU_KERNEL="initrd.img-5.19.0-1004-raspi"
-echo "Movinng our /boot/initramfs.gz to /boot/${__UBUNTU_KERNEL}."
+echo "Moving our /boot/initramfs.gz to /boot/${__UBUNTU_KERNEL}."
 mv "/boot/${__UBUNTU_KERNEL}" "/boot/${__UBUNTU_KERNEL}-oos"
 cp /boot/initramfs.gz /boot/initrd.img
 mv /boot/initramfs.gz "/boot/${__UBUNTU_KERNEL}"

--- a/hooks/0000-experimental-initramfs-sshjump.hook
+++ b/hooks/0000-experimental-initramfs-sshjump.hook
@@ -165,7 +165,7 @@ EOT
     chmod +x "${CHROOTDIR}/etc/initramfs-tools/scripts/local-bottom/kill_sshjump"
 
 
-    echo_debug "Creating script to removes this key from SSHJUMP: ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_remove"
+    echo_debug "Creating script to remove this key from SSHJUMP: ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_remove"
     cat <<EOT > ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_remove
 #!/bin/bash
 cat ${_KEYFILE}.pub | ssh ${_SSHJUMP_USERNAME}@${_SSHJUMP_SERVER} pubkey rm
@@ -208,7 +208,7 @@ Host ${_SSHJUMP_REFERENCE}-boot
 ${_ENTRYCOMMENT}-end
 EOT
 
-    echo_debug "    Removing unecessary empty lines"
+    echo_debug "    Removing unnecessary empty lines"
     sed -i 'N;/^\n$/D;P;D;' $_USER_HOME/.ssh/config
 
 

--- a/hooks/0000-experimental-initramfs-wifi.hook
+++ b/hooks/0000-experimental-initramfs-wifi.hook
@@ -18,7 +18,7 @@ if [ -z "${_INITRAMFS_WIFI_INTERFACE}" ]; then
 fi
 
 
-# Checking if WIFI ip kernal param was provided
+# Checking if WIFI ip kernel param was provided
 if [ -z "${_INITRAMFS_WIFI_IP}" ]; then
     _INITRAMFS_WIFI_IP=":::::${_INITRAMFS_WIFI_INTERFACE}:dhcp:${_DNS1}:${_DNS2}"
     echo_warn "_INITRAMFS_WIFI_IP is not set on config: Setting default value ${_INITRAMFS_WIFI_IP}"

--- a/hooks/0000-experimental-sys-sshjump.hook
+++ b/hooks/0000-experimental-sys-sshjump.hook
@@ -75,7 +75,7 @@ EOT
     chroot_execute systemctl enable sshjump.service
 
 
-    echo_debug "Creating script to removes this key from SSHJUMP: ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_remove"
+    echo_debug "Creating script to remove this key from SSHJUMP: ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_remove"
     cat <<EOT > ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_remove
 #!/bin/bash
 cat ${_KEYFILE}.pub | ssh ${_SSHJUMP_USERNAME}@${_SSHJUMP_SERVER} pubkey rm
@@ -119,7 +119,7 @@ Host ${_SSHJUMP_REFERENCE}-sys
 ${_ENTRYCOMMENT}-end
 EOT
 
-    echo_debug "    Removing unecessary empty lines"
+    echo_debug "    Removing unnecessary empty lines"
     sed -i 'N;/^\n$/D;P;D;' $_USER_HOME/.ssh/config
 
 

--- a/hooks/0000-optional-initramfs-sshhub.hook
+++ b/hooks/0000-optional-initramfs-sshhub.hook
@@ -163,7 +163,7 @@ EOT
     chmod +x "${CHROOTDIR}/etc/initramfs-tools/scripts/local-bottom/kill_sshhub"
 
 
-    echo_debug "Creating script to removes this key from SSHHUB: ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_remove"
+    echo_debug "Creating script to remove this key from SSHHUB: ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_remove"
     cat <<EOT > ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_remove
 #!/bin/bash
 cat ${_KEYFILE}.pub | ssh ${_SSHHUB_USERNAME}@sshhub.de pubkey rm
@@ -206,7 +206,7 @@ Host ${_SSHHUB_REFERENCE}-boot
 ${_ENTRYCOMMENT}-end
 EOT
 
-    echo_debug "    Removing unecessary empty lines"
+    echo_debug "    Removing unnecessary empty lines"
     sed -i 'N;/^\n$/D;P;D;' $_USER_HOME/.ssh/config
 
 

--- a/hooks/0000-optional-sys-dns.hook
+++ b/hooks/0000-optional-sys-dns.hook
@@ -26,7 +26,7 @@ chmod o+r ${CHROOTDIR}/etc/resolv.conf
 #EOT
 
 
-echo_debug "Uptading /etc/network/interfaces"
+echo_debug "Updating /etc/network/interfaces"
 cat <<EOT >> ${CHROOTDIR}/etc/network/interfaces
 
 # DNS (by optional-sys-dns)
@@ -36,7 +36,7 @@ EOT
 
 
 test -e "${CHROOTDIR}/etc/dhclient.conf" && {
-    echo_debug "Uptading /etc/dhclient.conf"
+    echo_debug "Updating /etc/dhclient.conf"
     cat <<EOT >> ${CHROOTDIR}/etc/dhclient.conf
 
 # DNS (by optional-sys-dns)
@@ -46,7 +46,7 @@ EOT
 
 
 test -e "${CHROOTDIR}/etc/dhpc/dhclient.conf" && {
-    echo_debug "Uptading /etc/dhpc/dhclient.conf"
+    echo_debug "Updating /etc/dhpc/dhclient.conf"
     cat <<EOT >> ${CHROOTDIR}/etc/dhpc/dhclient.conf
 
 # DNS (by optional-sys-dns)

--- a/hooks/0000-optional-sys-sshhub.hook
+++ b/hooks/0000-optional-sys-sshhub.hook
@@ -73,7 +73,7 @@ EOT
     chroot_execute systemctl enable sshhub.service
 
 
-    echo_debug "Creating script to removes this key from SSHHUB: ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_remove"
+    echo_debug "Creating script to remove this key from SSHHUB: ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_remove"
     cat <<EOT > ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_remove
 #!/bin/bash
 cat ${_KEYFILE}.pub | ssh ${_SSHHUB_USERNAME}@sshhub.de pubkey rm
@@ -117,7 +117,7 @@ Host ${_SSHHUB_REFERENCE}-sys
 ${_ENTRYCOMMENT}-end
 EOT
 
-    echo_debug "    Removing unecessary empty lines"
+    echo_debug "    Removing unnecessary empty lines"
     sed -i 'N;/^\n$/D;P;D;' $_USER_HOME/.ssh/config
 
 

--- a/hooks/0000-optional-sys-vpnclient.hook
+++ b/hooks/0000-optional-sys-vpnclient.hook
@@ -13,7 +13,7 @@ if [ -f ${_OPENVPN_CONFIG_ZIPPATH} ]; then
     chroot_pkginstall openvpn
     mkdir -p ${CHROOTDIR}/etc/openvpn
 
-    echo_debug "Unzipping provided files into configuraiton dir"
+    echo_debug "Unzipping provided files into configuration dir"
     unzip ${_OPENVPN_CONFIG_ZIPPATH} -d ${CHROOTDIR}/etc/openvpn/
 
     echo_debug "Setting AUTOSTART to ALL on OPENVPN config"

--- a/hooks/0000-optional-sys-wifi.hook
+++ b/hooks/0000-optional-sys-wifi.hook
@@ -31,7 +31,7 @@ ${_WIFI_PSK}
 EOT
 
 
-echo_debug "Uptading /etc/network/interfaces file"
+echo_debug "Updating /etc/network/interfaces file"
 cat <<EOT >> ${CHROOTDIR}/etc/network/interfaces
 
 # The buildin wireless interface


### PR DESCRIPTION
I reviewed the whole code base and fixed some typos and grammatical errors. The only functional change is in *stage1-otherscript.sh*:
Before:
```bash
systemctl disable userconfig > /dev/null 2&>1
```
After:
```bash
systemctl disable userconfig > /dev/null 2>&1
```