### PR TITLE
Fix spellcheck warnings (SC2086, SC2006) in *.fns, *.hook, *.conf, stage2-otherscript.sh, mini-kali-image and cryptmypi.sh files.

### DIFF
--- a/cryptmypi.sh
+++ b/cryptmypi.sh
@@ -206,7 +206,7 @@ _SCRIPT_DIRECTORY="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 
 # Variables
-export _USER_HOME=$(eval echo ~${SUDO_USER})
+export _USER_HOME=$(eval echo ~"${SUDO_USER}")
 export _VER="4.12-next"
 export _BASEDIR="${_SCRIPT_DIRECTORY}"
 export _CURRDIR=$(pwd)
@@ -223,7 +223,7 @@ mkdir -p "${_FILESDIR}"
 
 
 # Check if configuration file is present
-if [ ! -f ${_CONFDIR}/cryptmypi.conf ]; then
+if [ ! -f "${_CONFDIR}"/cryptmypi.conf ]; then
     cat << EOF
 ERROR: No 'cryptmypi.conf' file found in the config folder!
 
@@ -237,7 +237,7 @@ fi
 
 
 # Load configuration file
-. ${_CONFDIR}/cryptmypi.conf
+. "${_CONFDIR}"/cryptmypi.conf
 
 
 # Overriding _BLKDEV if _BLKDEV_OVERRIDE set
@@ -245,19 +245,19 @@ fi
 
 
 # Configuration dependent variables
-export _IMAGENAME=$(basename ${_IMAGEURL})
+export _IMAGENAME=$(basename "${_IMAGEURL}")
 
 
 ############################
 # Load Script Base Functions
 ############################
 echo "Loading functions..."
-for _FN in ${_BASEDIR}/functions/*.fns
+for _FN in "${_BASEDIR}"/functions/*.fns
 do
-    if [ -e ${_FN} ]; then
-        echo "- Loading $(basename ${_FN}) ..."
-        source ${_FN}
-        echo "  ... $(basename ${_FN}) loaded!"
+    if [ -e "${_FN}" ]; then
+        echo "- Loading $(basename "${_FN}") ..."
+        source "${_FN}"
+        echo "  ... $(basename "${_FN}") loaded!"
     fi
 done
 
@@ -332,7 +332,7 @@ EOF
 ############################
 stage2(){
     # Simple check for type of sdcard block device
-    if echo ${_BLKDEV} | grep -qs "mmcblk"
+    if echo "${_BLKDEV}" | grep -qs "mmcblk"
     then
         __PARTITIONPREFIX=p
     else
@@ -427,8 +427,8 @@ EOF
 ############################
 # Logic execution routine
 execute(){
-    mkdir -p ${_BUILDDIR}
-    cd ${_BUILDDIR}
+    mkdir -p "${_BUILDDIR}"
+    cd "${_BUILDDIR}"
     case "$1" in
         'both')
             echo "# Executing both stages #######################################################"
@@ -448,7 +448,7 @@ execute(){
 # Cleanup EXIT Trap
 cleanup(){
     chroot_umount || true
-    umount ${_BLKDEV}* || true
+    umount "${_BLKDEV}"* || true
     umount /mnt/cryptmypi || {
         umount -l /mnt/cryptmypi || true
         umount -f /dev/mapper/crypt || true
@@ -461,7 +461,7 @@ trap cleanup EXIT
 
 # Main logic routine
 main(){
-    if [ ! -d ${_BUILDDIR} ]; then
+    if [ ! -d "${_BUILDDIR}" ]; then
         execute "both"
     else
         restore_output
@@ -473,7 +473,7 @@ main(){
             $_STAGE1_CONFIRM && {
                 echo "Rebuild? (y/N)"
                 read _CONTINUE
-                _CONTINUE=`echo "${_CONTINUE}" | sed -e 's/\(.*\)/\L\1/'`
+                _CONTINUE=$(echo "${_CONTINUE}" | sed -e 's/\(.*\)/\L\1/')
             } || {
                 echo "STAGE1 confirmation set to FALSE: skipping confirmation"
                 $_STAGE1_REBUILD && {
@@ -491,7 +491,7 @@ main(){
                 'y')
                     $_RMBUILD_ONREBUILD && {
                         echo "Removing current build files..."
-                        $_SIMULATE || rm -Rf ${_BUILDDIR}
+                        $_SIMULATE || rm -Rf "${_BUILDDIR}"
                     } || echo_warn "--keep_build_dir set: Not cleaning old build."
                     execute "both"
                     break;

--- a/examples/debian-encrypted-basic-dropbear/stage2-otherscript.sh
+++ b/examples/debian-encrypted-basic-dropbear/stage2-otherscript.sh
@@ -6,7 +6,7 @@
 
 # At the time of testing the Debian OS for RPi works on labels, so we attempt to match.
 echo 'Setting up partition labels for Debian OS.'
-dosfslabel ${_BLKDEV}1 RASPIFIRM
+dosfslabel "${_BLKDEV}"1 RASPIFIRM
 
 
 # https://cryptsetup-team.pages.debian.net/cryptsetup/README.initramfs.html#cryptopts-boot-argument

--- a/examples/debian-unencrypted/stage2-otherscript.sh
+++ b/examples/debian-unencrypted/stage2-otherscript.sh
@@ -6,8 +6,8 @@
 
 # At the time of testing the Debian for RPi works on labels, so we attempt to match.
 echo 'Setting up partition labels for Debian.'
-dosfslabel ${_BLKDEV}1 RASPIFIRM
-e2label ${_BLKDEV}2 RASPIROOT
+dosfslabel "${_BLKDEV}"1 RASPIFIRM
+e2label "${_BLKDEV}"2 RASPIROOT
 
 
 # Move our kernel in place of the targets default kernel

--- a/examples/explore/cryptmypi.conf
+++ b/examples/explore/cryptmypi.conf
@@ -12,13 +12,13 @@ fi
 _REAL_CONFDIRNAME=$2
 
 
-. ${_REAL_CONFDIRNAME}/cryptmypi.conf
+. "${_REAL_CONFDIRNAME}"/cryptmypi.conf
 
 
 # Overwrites Stage 1
 stage1_hooks(){
     echo "----- SKIPPING STAGE 1, HACKING THE SYSTEM!!!"
-    rm -Rf ${_BUILDDIR}
+    rm -Rf "${_BUILDDIR}"
     export _CONFDIRNAME=${_REAL_CONFDIRNAME}
     export _CONFDIR=${_BASEDIR}/${_CONFDIRNAME}
     export _BUILDDIR=${_CONFDIR}/build
@@ -49,7 +49,7 @@ stage2_optional_hooks(){
 
     echo "System is available at ${CHROOTDIR}"
     echo "chrooting..."
-    chroot ${CHROOTDIR} /bin/bash
+    chroot "${CHROOTDIR}" /bin/bash
     echo
     read -p "Press enter to teardown."
 }

--- a/examples/kali-complete/stage2-otherscript.sh
+++ b/examples/kali-complete/stage2-otherscript.sh
@@ -8,7 +8,7 @@ systemctl disable rpiwiggle.service
 
 echo 'Adjusting root= in /boot/cmdline.txt'
 __OLDROOT=$(awk '{print $3}' /boot/cmdline.txt)
-echo Old crypt ROOT is $__OLDROOT
+echo Old crypt ROOT is "$__OLDROOT"
 __NEWROOT="root=/dev/mapper/crypt"
 echo New crypt ROOT is $__NEWROOT
 sed -i.bak "s#$__OLDROOT#$__NEWROOT#" /boot/cmdline.txt
@@ -16,12 +16,12 @@ sed -i.bak "s#$__OLDROOT#$__NEWROOT#" /boot/cmdline.txt
 
 echo 'Replacing UUID to encrypted path in /etc/fstab'
 __OLDUUID=$(grep UUID /etc/fstab | awk '{print $1}')
-echo Old fstab UUID is $__OLDUUID
+echo Old fstab UUID is "$__OLDUUID"
 __NEWPATH="/dev/mapper/crypt"
 echo New crypt path in fstab is $__NEWPATH
 sed -i.bak "s#$__OLDUUID#$__NEWPATH#" /etc/fstab
 
 
 echo "Set a label for system check on ${_BLKDEV}1 "
-dosfslabel ${_BLKDEV}1 BOOT
+dosfslabel "${_BLKDEV}"1 BOOT
 

--- a/examples/kali-encrypted-basic-dropbear/stage2-otherscript.sh
+++ b/examples/kali-encrypted-basic-dropbear/stage2-otherscript.sh
@@ -8,7 +8,7 @@ systemctl disable rpiwiggle.service
 
 echo 'Adjusting root= in /boot/cmdline.txt'
 __OLDROOT=$(awk '{print $3}' /boot/cmdline.txt)
-echo Old crypt ROOT is $__OLDROOT
+echo Old crypt ROOT is "$__OLDROOT"
 __NEWROOT="root=/dev/mapper/crypt"
 echo New crypt ROOT is $__NEWROOT
 sed -i.bak "s#$__OLDROOT#$__NEWROOT#" /boot/cmdline.txt
@@ -16,12 +16,12 @@ sed -i.bak "s#$__OLDROOT#$__NEWROOT#" /boot/cmdline.txt
 
 echo 'Replacing UUID to encrypted path in /etc/fstab'
 __OLDUUID=$(grep UUID /etc/fstab | awk '{print $1}')
-echo Old fstab UUID is $__OLDUUID
+echo Old fstab UUID is "$__OLDUUID"
 __NEWPATH="/dev/mapper/crypt"
 echo New crypt path in fstab is $__NEWPATH
 sed -i.bak "s#$__OLDUUID#$__NEWPATH#" /etc/fstab
 
 
 echo "Set a label for system check on ${_BLKDEV}1 "
-dosfslabel ${_BLKDEV}1 BOOT
+dosfslabel "${_BLKDEV}"1 BOOT
 

--- a/examples/kali-encrypted-basic-nuke/stage2-otherscript.sh
+++ b/examples/kali-encrypted-basic-nuke/stage2-otherscript.sh
@@ -8,7 +8,7 @@ systemctl disable rpiwiggle.service
 
 echo 'Adjusting root= in /boot/cmdline.txt'
 __OLDROOT=$(awk '{print $3}' /boot/cmdline.txt)
-echo Old crypt ROOT is $__OLDROOT
+echo Old crypt ROOT is "$__OLDROOT"
 __NEWROOT="root=/dev/mapper/crypt"
 echo New crypt ROOT is $__NEWROOT
 sed -i.bak "s#$__OLDROOT#$__NEWROOT#" /boot/cmdline.txt
@@ -16,12 +16,12 @@ sed -i.bak "s#$__OLDROOT#$__NEWROOT#" /boot/cmdline.txt
 
 echo 'Replacing UUID to encrypted path in /etc/fstab'
 __OLDUUID=$(grep UUID /etc/fstab | awk '{print $1}')
-echo Old fstab UUID is $__OLDUUID
+echo Old fstab UUID is "$__OLDUUID"
 __NEWPATH="/dev/mapper/crypt"
 echo New crypt path in fstab is $__NEWPATH
 sed -i.bak "s#$__OLDUUID#$__NEWPATH#" /etc/fstab
 
 
 echo "Set a label for system check on ${_BLKDEV}1 "
-dosfslabel ${_BLKDEV}1 BOOT
+dosfslabel "${_BLKDEV}"1 BOOT
 

--- a/examples/kali-encrypted-basic/stage2-otherscript.sh
+++ b/examples/kali-encrypted-basic/stage2-otherscript.sh
@@ -8,7 +8,7 @@ systemctl disable rpiwiggle.service
 
 echo 'Adjusting root= in /boot/cmdline.txt'
 __OLDROOT=$(awk '{print $3}' /boot/cmdline.txt)
-echo Old crypt ROOT is $__OLDROOT
+echo Old crypt ROOT is "$__OLDROOT"
 __NEWROOT="root=/dev/mapper/crypt"
 echo New crypt ROOT is $__NEWROOT
 sed -i.bak "s#$__OLDROOT#$__NEWROOT#" /boot/cmdline.txt
@@ -16,12 +16,12 @@ sed -i.bak "s#$__OLDROOT#$__NEWROOT#" /boot/cmdline.txt
 
 echo 'Replacing UUID to encrypted path in /etc/fstab'
 __OLDUUID=$(grep UUID /etc/fstab | awk '{print $1}')
-echo Old fstab UUID is $__OLDUUID
+echo Old fstab UUID is "$__OLDUUID"
 __NEWPATH="/dev/mapper/crypt"
 echo New crypt path in fstab is $__NEWPATH
 sed -i.bak "s#$__OLDUUID#$__NEWPATH#" /etc/fstab
 
 
 echo "Set a label for system check on ${_BLKDEV}1 "
-dosfslabel ${_BLKDEV}1 BOOT
+dosfslabel "${_BLKDEV}"1 BOOT
 

--- a/examples/kali-encrypted-docker-tor-irssi/stage2-otherscript.sh
+++ b/examples/kali-encrypted-docker-tor-irssi/stage2-otherscript.sh
@@ -8,7 +8,7 @@ systemctl disable rpiwiggle.service
 
 echo 'Adjusting root= in /boot/cmdline.txt'
 __OLDROOT=$(awk '{print $3}' /boot/cmdline.txt)
-echo Old crypt ROOT is $__OLDROOT
+echo Old crypt ROOT is "$__OLDROOT"
 __NEWROOT="root=/dev/mapper/crypt"
 echo New crypt ROOT is $__NEWROOT
 sed -i.bak "s#$__OLDROOT#$__NEWROOT#" /boot/cmdline.txt
@@ -16,12 +16,12 @@ sed -i.bak "s#$__OLDROOT#$__NEWROOT#" /boot/cmdline.txt
 
 echo 'Replacing UUID to encrypted path in /etc/fstab'
 __OLDUUID=$(grep UUID /etc/fstab | awk '{print $1}')
-echo Old fstab UUID is $__OLDUUID
+echo Old fstab UUID is "$__OLDUUID"
 __NEWPATH="/dev/mapper/crypt"
 echo New crypt path in fstab is $__NEWPATH
 sed -i.bak "s#$__OLDUUID#$__NEWPATH#" /etc/fstab
 
 
 echo "Set a label for system check on ${_BLKDEV}1 "
-dosfslabel ${_BLKDEV}1 BOOT
+dosfslabel "${_BLKDEV}"1 BOOT
 

--- a/examples/kali-encrypted-sshhub/stage2-otherscript.sh
+++ b/examples/kali-encrypted-sshhub/stage2-otherscript.sh
@@ -8,7 +8,7 @@ systemctl disable rpiwiggle.service
 
 echo 'Adjusting root= in /boot/cmdline.txt'
 __OLDROOT=$(awk '{print $3}' /boot/cmdline.txt)
-echo Old crypt ROOT is $__OLDROOT
+echo Old crypt ROOT is "$__OLDROOT"
 __NEWROOT="root=/dev/mapper/crypt"
 echo New crypt ROOT is $__NEWROOT
 sed -i.bak "s#$__OLDROOT#$__NEWROOT#" /boot/cmdline.txt
@@ -16,12 +16,12 @@ sed -i.bak "s#$__OLDROOT#$__NEWROOT#" /boot/cmdline.txt
 
 echo 'Replacing UUID to encrypted path in /etc/fstab'
 __OLDUUID=$(grep UUID /etc/fstab | awk '{print $1}')
-echo Old fstab UUID is $__OLDUUID
+echo Old fstab UUID is "$__OLDUUID"
 __NEWPATH="/dev/mapper/crypt"
 echo New crypt path in fstab is $__NEWPATH
 sed -i.bak "s#$__OLDUUID#$__NEWPATH#" /etc/fstab
 
 
 echo "Set a label for system check on ${_BLKDEV}1 "
-dosfslabel ${_BLKDEV}1 BOOT
+dosfslabel "${_BLKDEV}"1 BOOT
 

--- a/examples/kali-unencrypted/stage2-otherscript.sh
+++ b/examples/kali-unencrypted/stage2-otherscript.sh
@@ -15,21 +15,21 @@ sed -i.bak "s#rootfstype=ext3#rootfstype=ext4#g" /boot/cmdline.txt
 
 echo 'Adjusting PARTUUID in /boot/cmdline.txt'
 __OLDPARTUUID=$(awk '{print $3}' /boot/cmdline.txt | awk -F= '{print $3}')
-echo Old PARTUUID is $__OLDPARTUUID
-__NEWPARTUUID=$(blkid | grep ${_BLKDEV}2 | awk '{print $5}' | awk -F\" '{print $2}')
-echo New PARTUUID is $__NEWPARTUUID
+echo Old PARTUUID is "$__OLDPARTUUID"
+__NEWPARTUUID=$(blkid | grep "${_BLKDEV}"2 | awk '{print $5}' | awk -F\" '{print $2}')
+echo New PARTUUID is "$__NEWPARTUUID"
 sed -i.bak "s/$__OLDPARTUUID/$__NEWPARTUUID/" /boot/cmdline.txt
 
 
 echo 'Adjusting UUID in /etc/fstab'
 __OLDUUID=$(grep UUID /etc/fstab | awk '{print $1}' | awk -F= '{print $2}')
-echo Old UUID is $__OLDUUID
-__NEWUUID=$(blkid | grep ${_BLKDEV}2 | awk '{print $2}' | awk -F\" '{print $2}')
-echo New UUID is $__NEWUUID
+echo Old UUID is "$__OLDUUID"
+__NEWUUID=$(blkid | grep "${_BLKDEV}"2 | awk '{print $2}' | awk -F\" '{print $2}')
+echo New UUID is "$__NEWUUID"
 sed -i.bak "s/$__OLDUUID/$__NEWUUID/" /etc/fstab
 
 
 echo "Set a label for system check on ${_BLKDEV}1 "
-dosfslabel ${_BLKDEV}1 BOOT
+dosfslabel "${_BLKDEV}"1 BOOT
 
 

--- a/examples/ubuntu-encrypted-basic/stage2-otherscript.sh
+++ b/examples/ubuntu-encrypted-basic/stage2-otherscript.sh
@@ -6,7 +6,7 @@
 
 # At the time of testing the Ubuntu for RPi works on labels, so we attempt to match.
 echo 'Setting up partition labels for Ubuntu.'
-dosfslabel ${_BLKDEV}1 system-boot
+dosfslabel "${_BLKDEV}"1 system-boot
 
 
 # https://cryptsetup-team.pages.debian.net/cryptsetup/README.initramfs.html#cryptopts-boot-argument

--- a/examples/ubuntu-unencrypted/stage2-otherscript.sh
+++ b/examples/ubuntu-unencrypted/stage2-otherscript.sh
@@ -6,8 +6,8 @@
 
 # At the time of testing the Ubuntu for RPi works on labels, so we attempt to match.
 echo 'Setting up partition labels for Ubuntu.'
-dosfslabel ${_BLKDEV}1 system-boot
-e2label ${_BLKDEV}2 writable
+dosfslabel "${_BLKDEV}"1 system-boot
+e2label "${_BLKDEV}"2 writable
 
 
 # Move our kernel in place of the targets default kernel

--- a/functions/chroot.fns
+++ b/functions/chroot.fns
@@ -9,18 +9,18 @@ chroot_mount(){
 
     # mount binds
     echo_debug "Mounting '${CHROOTDIR}/dev/' ..."
-    mount --bind /dev ${CHROOTDIR}/dev/ || echo_error "   ... ERROR while mounting '${CHROOTDIR}/dev/'"
+    mount --bind /dev "${CHROOTDIR}"/dev/ || echo_error "   ... ERROR while mounting '${CHROOTDIR}/dev/'"
     echo_debug "Mounting '${CHROOTDIR}/dev/pts' ..."
-    mount --bind /dev/pts ${CHROOTDIR}/dev/pts || echo_error "   ... ERROR while mounting '${CHROOTDIR}/dev/pts'"
+    mount --bind /dev/pts "${CHROOTDIR}"/dev/pts || echo_error "   ... ERROR while mounting '${CHROOTDIR}/dev/pts'"
     echo_debug "Mounting '${CHROOTDIR}/sys/' ..."
-    mount --bind /sys ${CHROOTDIR}/sys/ || echo_error "   ... ERROR while mounting '${CHROOTDIR}/sys/'"
+    mount --bind /sys "${CHROOTDIR}"/sys/ || echo_error "   ... ERROR while mounting '${CHROOTDIR}/sys/'"
     echo_debug "Mounting '${CHROOTDIR}/proc/' ..."
-    mount -t proc /proc ${CHROOTDIR}/proc/ || echo_error "   ... ERROR while mounting '${CHROOTDIR}/proc/'"
+    mount -t proc /proc "${CHROOTDIR}"/proc/ || echo_error "   ... ERROR while mounting '${CHROOTDIR}/proc/'"
 
     # ld.so.preload fix
-    test -e ${CHROOTDIR}/etc/ld.so.preload && {
+    test -e "${CHROOTDIR}"/etc/ld.so.preload && {
         echo_debug "Fixing ld.so.preload"
-        sed -i 's/^/#CHROOT /g' ${CHROOTDIR}/etc/ld.so.preload
+        sed -i 's/^/#CHROOT /g' "${CHROOTDIR}"/etc/ld.so.preload
     } || true
 }
 
@@ -32,14 +32,14 @@ chroot_umount(){
     echo_debug "Tearing down RPi chroot mount structure at '${CHROOTDIR}'."
 
     # revert ld.so.preload fix
-    test -e ${CHROOTDIR}/etc/ld.so.preload && {
+    test -e "${CHROOTDIR}"/etc/ld.so.preload && {
         echo_debug "Reverting ld.so.preload fix"
-        sed -i 's/^#CHROOT //g' ${CHROOTDIR}/etc/ld.so.preload
+        sed -i 's/^#CHROOT //g' "${CHROOTDIR}"/etc/ld.so.preload
     } || true
 
     # unmount everything
     echo_debug "Unmounting binds"
-    umount ${CHROOTDIR}/{dev/pts,dev,sys,proc}
+    umount "${CHROOTDIR}"/{dev/pts,dev,sys,proc}
 
     export CHROOTDIR=''
 }
@@ -61,7 +61,7 @@ chroot_update(){
     fi
 
     echo_debug "Updating apt-get"
-    chroot ${CHROOTDIR} apt-get update
+    chroot "${CHROOTDIR}" apt-get update
 }
 
 
@@ -75,9 +75,9 @@ chroot_pkginstall(){
         for param in "$@"; do
             for pkg in $param; do
                 echo_debug "- Installing ${pkg}"
-                chroot ${CHROOTDIR} apt-get -y install "${pkg}" || {
+                chroot "${CHROOTDIR}" apt-get -y install "${pkg}" || {
                     echo_warn "apt-get failed: Trying to recover..."
-                    chroot ${CHROOTDIR} /bin/bash -x <<EOF
+                    chroot "${CHROOTDIR}" /bin/bash -x <<EOF
                         sleep 5
                         apt-get update
                         apt-get -y install "${pkg}" || exit 1
@@ -104,10 +104,10 @@ chroot_pkgpurge(){
         for param in "$@"; do
             for pkg in $param; do
                 echo_debug "- Purging ${pkg}"
-                chroot ${CHROOTDIR} apt-get -y purge "${pkg}"
+                chroot "${CHROOTDIR}" apt-get -y purge "${pkg}"
             done
         done
-        chroot ${CHROOTDIR} apt-get -y autoremove
+        chroot "${CHROOTDIR}" apt-get -y autoremove
     fi
 }
 
@@ -118,7 +118,7 @@ chroot_execute(){
         exit 1
     }
 
-    chroot ${CHROOTDIR} "$@"
+    chroot "${CHROOTDIR}" "$@"
 }
 
 
@@ -131,13 +131,13 @@ chroot_mkinitramfs(){
     test -e "/dev/mmcblk0p2" || (test -e "/${_BLKDEV}2" && ln -s "/${_BLKDEV}2" "/dev/mmcblk0p2")
 
     # determining the kernel
-    _KERNEL_VERSION=$(ls ${CHROOTDIR}/lib/modules/ | grep "${_KERNEL_VERSION_FILTER}" | tail -n 1)
+    _KERNEL_VERSION=$(ls "${CHROOTDIR}"/lib/modules/ | grep "${_KERNEL_VERSION_FILTER}" | tail -n 1)
     echo_debug "  Using kernel '${_KERNEL_VERSION}'"
 
     # Finally, Create the initramfs
     echo_debug "  Building new initramfs ..."
     #chroot_execute update-initramfs -u # -k ${_KERNEL_VERSION} # TODO Test this + test without it completely
-    chroot_execute mkinitramfs -o /boot/initramfs.gz -v ${_KERNEL_VERSION}
+    chroot_execute mkinitramfs -o /boot/initramfs.gz -v "${_KERNEL_VERSION}"
 
     # cleanup
     echo_debug "  Cleaning up symbolic links"

--- a/functions/files.fns
+++ b/functions/files.fns
@@ -1,7 +1,7 @@
 lazy_download(){
     local _URL=$1
     local _DEST=$2
-    local _URLMD5=`/bin/echo ${_URL} | /usr/bin/md5sum | /bin/cut -f1 -d" "`
+    local _URLMD5=$(/bin/echo "${_URL}" | /usr/bin/md5sum | /bin/cut -f1 -d" ")
     local _FILENAME="${_URLMD5}_$(basename "${_URL}")"
     local _DOWNLOAD_FILEPATH=${_CACHEDIR}/${_FILENAME}
 
@@ -11,7 +11,7 @@ lazy_download(){
         echo_debug "    File ${_FILENAME} already exists on cache!"
     else
         echo_debug "    Downloading file from ${_URL} ..."
-        wget ${_URL} -O "${_DOWNLOAD_FILEPATH}"
+        wget "${_URL}" -O "${_DOWNLOAD_FILEPATH}"
     fi
 
     echo_debug "    ... saving it to ${_DEST}."

--- a/functions/hooks.fns
+++ b/functions/hooks.fns
@@ -4,14 +4,14 @@ myhooks(){
         _HOOKOP="${1}"
         echo ""
         echo_info "Attempting to run ${_HOOKOP} hooks ..."
-        for _HOOK in ${_BASEDIR}/hooks/????-${_HOOKOP}*.hook
+        for _HOOK in "${_BASEDIR}"/hooks/????-"${_HOOKOP}"*.hook
         do
-            if [ -e ${_HOOK} ]; then
-                echo_info "- Calling $(basename ${_HOOK}) ..."
+            if [ -e "${_HOOK}" ]; then
+                echo_info "- Calling $(basename "${_HOOK}") ..."
                 $_SIMULATE && {
                     echo "SKIPPING: Simulation mode active: Hook will not be executed."
-                } || source ${_HOOK}
-                echo_info "    ... $(basename ${_HOOK}) completed!"
+                } || source "${_HOOK}"
+                echo_info "    ... $(basename "${_HOOK}") completed!"
                 echo ""
             fi
         done

--- a/functions/misc.fns
+++ b/functions/misc.fns
@@ -5,7 +5,7 @@ function_exists(){
 
 
 function_summary(){
-    type $1 | sed '1,3d;$d'
+    type "$1" | sed '1,3d;$d'
 }
 
 

--- a/functions/misc.fns
+++ b/functions/misc.fns
@@ -1,5 +1,5 @@
 function_exists(){
-    declare -f -F $1 > /dev/null
+    declare -f -F "$1" > /dev/null
     return $?
 }
 
@@ -10,8 +10,8 @@ function_summary(){
 
 
 is_build_encrypted(){
-    test -e ${_BUILDDIR}/root/etc/cryptsetup-initramfs/conf-hook && {
-        if grep -q "CRYPTSETUP=y" ${_BUILDDIR}/root/etc/cryptsetup-initramfs/conf-hook; then
+    test -e "${_BUILDDIR}"/root/etc/cryptsetup-initramfs/conf-hook && {
+        if grep -q "CRYPTSETUP=y" "${_BUILDDIR}"/root/etc/cryptsetup-initramfs/conf-hook; then
             return 0;
         else
             return 1;

--- a/functions/ssh.fns
+++ b/functions/ssh.fns
@@ -20,7 +20,7 @@ assure_box_sshkey(){
 
 backup_and_use_sshkey(){
     local _TMP_KEYPATH=$1
-    local _TMP_KEYNAME=$(basename ${_TMP_KEYPATH})
+    local _TMP_KEYNAME=$(basename "${_TMP_KEYPATH}")
 
     test -f "${_CONFDIR}/${_TMP_KEYNAME}" && {
         cp "${_CONFDIR}/${_TMP_KEYNAME}" "${_TMP_KEYPATH}"

--- a/hooks/0000-experimental-initramfs-iodine.hook
+++ b/hooks/0000-experimental-initramfs-iodine.hook
@@ -14,7 +14,7 @@ else
     chroot_pkginstall iodine
 
     # Create initramfs hook file for iodine
-    cat << 'EOF2' > ${CHROOTDIR}/etc/initramfs-tools/hooks/zz-iodine
+    cat << 'EOF2' > "${CHROOTDIR}"/etc/initramfs-tools/hooks/zz-iodine
 #!/bin/sh
 if [ "$1" = "prereqs" ]; then exit 0; fi
 . /usr/share/initramfs-tools/hook-functions
@@ -50,14 +50,14 @@ chmod 755 ${DESTDIR}/start_iodine
 
 exit 0
 EOF2
-    chmod 755 ${CHROOTDIR}/etc/initramfs-tools/hooks/zz-iodine
+    chmod 755 "${CHROOTDIR}"/etc/initramfs-tools/hooks/zz-iodine
 
     # Replace variables in iodine hook file
-    sed -i "s#IODINE_PASSWORD#${_IODINE_PASSWORD}#g" ${CHROOTDIR}/etc/initramfs-tools/hooks/zz-iodine
-    sed -i "s#IODINE_DOMAIN#${_IODINE_DOMAIN}#g" ${CHROOTDIR}/etc/initramfs-tools/hooks/zz-iodine
+    sed -i "s#IODINE_PASSWORD#${_IODINE_PASSWORD}#g" "${CHROOTDIR}"/etc/initramfs-tools/hooks/zz-iodine
+    sed -i "s#IODINE_DOMAIN#${_IODINE_DOMAIN}#g" "${CHROOTDIR}"/etc/initramfs-tools/hooks/zz-iodine
 
     # Create initramfs script file for iodine
-    cat << 'EOF' > ${CHROOTDIR}/etc/initramfs-tools/scripts/init-premount/iodine
+    cat << 'EOF' > "${CHROOTDIR}"/etc/initramfs-tools/scripts/init-premount/iodine
 #!/bin/sh
 if [ "$1" = "prereqs" ]; then exit 0; fi
 startIodine(){
@@ -66,7 +66,7 @@ startIodine(){
 startIodine &
 exit 0
 EOF
-    chmod 755 ${CHROOTDIR}/etc/initramfs-tools/scripts/init-premount/iodine
+    chmod 755 "${CHROOTDIR}"/etc/initramfs-tools/scripts/init-premount/iodine
 
     echo_debug "... iodine call completed!"
 fi

--- a/hooks/0000-experimental-initramfs-sshjump.hook
+++ b/hooks/0000-experimental-initramfs-sshjump.hook
@@ -37,9 +37,9 @@ else
     _SSHJUMP_ADDRESS="${_SSHJUMP_SERVER}"
     echo_debug "Registering box keyfile to sshjump (${_SSHJUMP_ADDRESS})"
     if [ -z "${_SSHJUMP_LOCAL_KEYFILE}" ]; then
-        ssh "${_SSHJUMP_USERNAME}@${_SSHJUMP_ADDRESS}" pubkey add $(cat "${_KEYFILE}.pub")
+        ssh "${_SSHJUMP_USERNAME}@${_SSHJUMP_ADDRESS}" pubkey add "$(cat "${_KEYFILE}.pub")"
     else
-        ssh -i "${_SSHJUMP_LOCAL_KEYFILE}" "${_SSHJUMP_USERNAME}@${_SSHJUMP_ADDRESS}" pubkey add $(cat "${_KEYFILE}.pub")
+        ssh -i "${_SSHJUMP_LOCAL_KEYFILE}" "${_SSHJUMP_USERNAME}@${_SSHJUMP_ADDRESS}" pubkey add "$(cat "${_KEYFILE}.pub")"
     fi
 
 
@@ -53,7 +53,7 @@ else
 
 
     echo_debug "Creating initramfs script sshjump_tunnel"
-    cat <<EOT > ${CHROOTDIR}/etc/initramfs-tools/scripts/local-top/sshjump_tunnel
+    cat <<EOT > "${CHROOTDIR}"/etc/initramfs-tools/scripts/local-top/sshjump_tunnel
 #!/bin/sh
 
 PREREQ=""
@@ -80,7 +80,7 @@ EOT
 
 
     echo_debug "Creating sshjump_tunnel.sh connection loop"
-    cat <<EOT > ${CHROOTDIR}/etc/initramfs-tools/ssh_tunnel.sh
+    cat <<EOT > "${CHROOTDIR}"/etc/initramfs-tools/ssh_tunnel.sh
 # !/bin/sh
 
 # Let everything get ready
@@ -98,7 +98,7 @@ EOT
 
 
     echo_debug "Creating initramfs hook sshjump_tunnel"
-    cat <<EOT > ${CHROOTDIR}/etc/initramfs-tools/hooks/sshjump_tunnel
+    cat <<EOT > "${CHROOTDIR}"/etc/initramfs-tools/hooks/sshjump_tunnel
 # !/bin/sh
 set -e
 
@@ -135,12 +135,12 @@ EOT
     echo_debug "Converting id_rsa to a dropbear key dropbear-id_rsa"
     cp "${_KEYFILE}" "${CHROOTDIR}/etc/initramfs-tools/id_rsa.tmp"
     ssh-keygen -m PEM -p -f "${CHROOTDIR}/etc/initramfs-tools/id_rsa.tmp" -q -N ""
-    chroot ${CHROOTDIR} /bin/bash -c "/usr/lib/dropbear/dropbearconvert openssh dropbear /etc/initramfs-tools/id_rsa.tmp /etc/initramfs-tools/dropbear-id_rsa"
+    chroot "${CHROOTDIR}" /bin/bash -c "/usr/lib/dropbear/dropbearconvert openssh dropbear /etc/initramfs-tools/id_rsa.tmp /etc/initramfs-tools/dropbear-id_rsa"
     rm "${CHROOTDIR}/etc/initramfs-tools/id_rsa.tmp"
 
 
     echo_debug "Creating initramfs script kill_sshjump"
-    cat <<EOT > ${CHROOTDIR}/etc/initramfs-tools/scripts/local-bottom/kill_sshjump
+    cat <<EOT > "${CHROOTDIR}"/etc/initramfs-tools/scripts/local-bottom/kill_sshjump
 #!/bin/sh
 
 PREREQ=""
@@ -166,22 +166,22 @@ EOT
 
 
     echo_debug "Creating script to remove this key from SSHJUMP: ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_remove"
-    cat <<EOT > ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_remove
+    cat <<EOT > "${_CONFDIR}"/sshjump_"${_SSHJUMP_REFERENCE}"_remove
 #!/bin/bash
 cat ${_KEYFILE}.pub | ssh ${_SSHJUMP_USERNAME}@${_SSHJUMP_SERVER} pubkey rm
 EOT
-    chmod +x ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_remove
+    chmod +x "${_CONFDIR}"/sshjump_"${_SSHJUMP_REFERENCE}"_remove
 
 
     echo_debug "Editing ~/.ssh/config"
 
     echo_debug "    Verifying if sshjump hub alias exists in $_USER_HOME/.ssh/config ..."
-    if test -f $_USER_HOME/.ssh/config && grep -q "^Host hub\s*" $_USER_HOME/.ssh/config
+    if test -f "$_USER_HOME"/.ssh/config && grep -q "^Host hub\s*" "$_USER_HOME"/.ssh/config
     then
         echo_debug "        ... sshjump host definition found."
     else
         echo_debug "        ... sshjump host definition not found: creating it"
-        cat <<EOT >> $_USER_HOME/.ssh/config
+        cat <<EOT >> "$_USER_HOME"/.ssh/config
 
 # cryptmypi-sshjump-entry-start
 Host hub
@@ -194,9 +194,9 @@ EOT
 
     echo_debug "    Creating/Replacing ${_SSHJUMP_REFERENCE}-boot host definition ..."
     _ENTRYCOMMENT="# cryptmypi-${_SSHJUMP_REFERENCE}-boot-entry"
-    sed -i "/^${_ENTRYCOMMENT}-start/,/^${_ENTRYCOMMENT}-end/{/^${_ENTRYCOMMENT}-start/!{/^${_ENTRYCOMMENT}-end/!d}}" $_USER_HOME/.ssh/config
-    sed -i "/${_ENTRYCOMMENT}/d" $_USER_HOME/.ssh/config
-cat <<EOT >> $_USER_HOME/.ssh/config
+    sed -i "/^${_ENTRYCOMMENT}-start/,/^${_ENTRYCOMMENT}-end/{/^${_ENTRYCOMMENT}-start/!{/^${_ENTRYCOMMENT}-end/!d}}" "$_USER_HOME"/.ssh/config
+    sed -i "/${_ENTRYCOMMENT}/d" "$_USER_HOME"/.ssh/config
+cat <<EOT >> "$_USER_HOME"/.ssh/config
 
 ${_ENTRYCOMMENT}-start
 Host ${_SSHJUMP_REFERENCE}-boot
@@ -209,7 +209,7 @@ ${_ENTRYCOMMENT}-end
 EOT
 
     echo_debug "    Removing unnecessary empty lines"
-    sed -i 'N;/^\n$/D;P;D;' $_USER_HOME/.ssh/config
+    sed -i 'N;/^\n$/D;P;D;' "$_USER_HOME"/.ssh/config
 
 
     echo_debug " ... ${_SSHJUMP_SERVER} INITRAMFS SSH channel set up! To connect, use:"

--- a/hooks/0000-experimental-initramfs-wifi.hook
+++ b/hooks/0000-experimental-initramfs-wifi.hook
@@ -33,7 +33,7 @@ fi
 
 
 # Update /boot/cmdline.txt to boot crypt
-sed -i "s#rootwait#ip=${_INITRAMFS_WIFI_IP} rootwait#g" ${CHROOTDIR}/boot/cmdline.txt
+sed -i "s#rootwait#ip=${_INITRAMFS_WIFI_IP} rootwait#g" "${CHROOTDIR}"/boot/cmdline.txt
 
 
 echo_debug "Generating PSK for '${_WIFI_SSID}' '${_WIFI_PASS}'"
@@ -41,7 +41,7 @@ _WIFI_PSK=$(wpa_passphrase "${_WIFI_SSID}" "${_WIFI_PASS}" | grep "psk=" | grep 
 
 
 echo_debug "Creating hook to include firmware files for brcmfmac"
-cat << EOF > ${_BUILDDIR}/root/etc/initramfs-tools/hooks/zz-brcm
+cat << EOF > "${_BUILDDIR}"/root/etc/initramfs-tools/hooks/zz-brcm
 # !/bin/sh
 set -e
 
@@ -64,11 +64,11 @@ echo "Copying firmware files for brcm to initramfs"
 cp -r /lib/firmware/brcm \${DESTDIR}/lib/firmware/
 
 EOF
-chmod 755 ${_BUILDDIR}/root/etc/initramfs-tools/hooks/zz-brcm
+chmod 755 "${_BUILDDIR}"/root/etc/initramfs-tools/hooks/zz-brcm
 
 
 echo_debug "Creating wpa_supplicant file"
-cat <<EOT > ${CHROOTDIR}/etc/initramfs-tools/wpa_supplicant.conf
+cat <<EOT > "${CHROOTDIR}"/etc/initramfs-tools/wpa_supplicant.conf
 ctrl_interface=/tmp/wpa_supplicant
 
 network={
@@ -81,7 +81,7 @@ EOT
 
 
 echo_debug "Creating initramfs script a_enable_wireless"
-cat <<EOT > ${CHROOTDIR}/etc/initramfs-tools/scripts/init-premount/a_enable_wireless
+cat <<EOT > "${CHROOTDIR}"/etc/initramfs-tools/scripts/init-premount/a_enable_wireless
 #!/bin/sh
 
 PREREQ=""
@@ -137,7 +137,7 @@ chmod +x "${CHROOTDIR}/etc/initramfs-tools/scripts/init-premount/a_enable_wirele
 
 
 echo_debug "Creating initramfs hook enable_wireless"
-cat <<EOT > ${CHROOTDIR}/etc/initramfs-tools/hooks/enable-wireless
+cat <<EOT > "${CHROOTDIR}"/etc/initramfs-tools/hooks/enable-wireless
 # !/bin/sh
 # This goes into /etc/initramfs-tools/hooks/enable-wireless
 set -e
@@ -168,7 +168,7 @@ chmod +x "${CHROOTDIR}/etc/initramfs-tools/hooks/enable-wireless"
 
 
 echo_debug "Creating initramfs script kill_wireless"
-cat <<EOT > ${CHROOTDIR}/etc/initramfs-tools/scripts/local-bottom/kill_wireless
+cat <<EOT > "${CHROOTDIR}"/etc/initramfs-tools/scripts/local-bottom/kill_wireless
 #!/bin/sh
 # this goes into /etc/initramfs-tools/scripts/local-bottom/kill_wireless
 PREREQ=""
@@ -191,7 +191,7 @@ chmod +x "${CHROOTDIR}/etc/initramfs-tools/scripts/local-bottom/kill_wireless"
 
 
 # Adding modules to initramfs modules
-for x in ${_INITRAMFS_WIFI_DRIVERS}; do echo ${x} >> ${CHROOTDIR}/etc/initramfs-tools/modules; done
+for x in ${_INITRAMFS_WIFI_DRIVERS}; do echo "${x}" >> "${CHROOTDIR}"/etc/initramfs-tools/modules; done
 
 
 echo_debug "... initramfs wifi completed!"

--- a/hooks/0000-experimental-sys-iodine.hook
+++ b/hooks/0000-experimental-sys-iodine.hook
@@ -14,21 +14,21 @@ else
     chroot_pkginstall iodine cron
 
     # Create iodine startup script (not initramfs)
-    cat << EOF > ${CHROOTDIR}/opt/iodine.sh
+    cat << EOF > "${CHROOTDIR}"/opt/iodine.sh
 #!/bin/bash
 while true; do
     iodine -f -r -I1 -L0 -P ${_IODINE_PASSWORD} ${_IODINE_DOMAIN}
     sleep 60
 done
 EOF
-    chmod 755 ${CHROOTDIR}/opt/iodine.sh
+    chmod 755 "${CHROOTDIR}"/opt/iodine.sh
 
-    cat << EOF > ${CHROOTDIR}/crontab_setup
+    cat << EOF > "${CHROOTDIR}"/crontab_setup
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 @reboot /opt/iodine.sh
 EOF
     chroot_execute crontab /crontab_setup
-    rm ${CHROOTDIR}/crontab_setup
+    rm "${CHROOTDIR}"/crontab_setup
 
     echo_debug "... iodine call completed!"
 fi

--- a/hooks/0000-experimental-sys-sshjump.hook
+++ b/hooks/0000-experimental-sys-sshjump.hook
@@ -30,19 +30,19 @@ else
 
     echo_debug "Registering box keyfile to sshjump"
     if [ -z "${_SSHJUMP_LOCAL_KEYFILE}" ]; then
-        ssh "${_SSHJUMP_USERNAME}@${_SSHJUMP_SERVER}" pubkey add $(cat "${_KEYFILE}.pub")
+        ssh "${_SSHJUMP_USERNAME}@${_SSHJUMP_SERVER}" pubkey add "$(cat "${_KEYFILE}.pub")"
     else
-        ssh -i "${_SSHJUMP_LOCAL_KEYFILE}" "${_SSHJUMP_USERNAME}@${_SSHJUMP_SERVER}" pubkey add $(cat "${_KEYFILE}.pub")
+        ssh -i "${_SSHJUMP_LOCAL_KEYFILE}" "${_SSHJUMP_USERNAME}@${_SSHJUMP_SERVER}" pubkey add "$(cat "${_KEYFILE}.pub")"
     fi
 
 
     echo_debug "Adding ${_SSHJUMP_SERVER} pub key to known_hosts..."
-    ssh-keyscan -H ${_SSHJUMP_SERVER} >> ${CHROOTDIR}/root/.ssh/known_hosts
-    chmod 644 ${CHROOTDIR}/root/.ssh/known_hosts
+    ssh-keyscan -H "${_SSHJUMP_SERVER}" >> "${CHROOTDIR}"/root/.ssh/known_hosts
+    chmod 644 "${CHROOTDIR}"/root/.ssh/known_hosts
 
 
     echo_debug "Creating script to create and maintain sshjump channel..."
-    cat <<EOT > ${CHROOTDIR}/opt/sys-sshjump-channel.sh
+    cat <<EOT > "${CHROOTDIR}"/opt/sys-sshjump-channel.sh
 #!/bin/bash
 
 while true
@@ -57,11 +57,11 @@ do
     }
 done
 EOT
-    chmod +x ${CHROOTDIR}/opt/sys-sshjump-channel.sh
+    chmod +x "${CHROOTDIR}"/opt/sys-sshjump-channel.sh
 
 
     echo_debug "Creating startup service"
-    cat <<EOT > ${CHROOTDIR}/etc/systemd/system/sshjump.service
+    cat <<EOT > "${CHROOTDIR}"/etc/systemd/system/sshjump.service
 [Unit]
 Description=sshjump
 
@@ -76,22 +76,22 @@ EOT
 
 
     echo_debug "Creating script to remove this key from SSHJUMP: ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_remove"
-    cat <<EOT > ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_remove
+    cat <<EOT > "${_CONFDIR}"/sshjump_"${_SSHJUMP_REFERENCE}"_remove
 #!/bin/bash
 cat ${_KEYFILE}.pub | ssh ${_SSHJUMP_USERNAME}@${_SSHJUMP_SERVER} pubkey rm
 EOT
-    chmod +x ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_remove
+    chmod +x "${_CONFDIR}"/sshjump_"${_SSHJUMP_REFERENCE}"_remove
 
 
     echo_debug "Editing ~/.ssh/config"
 
     echo_debug "    Verifying if sshjump hub alias exists in $_USER_HOME/.ssh/config ..."
-    if test -f $_USER_HOME/.ssh/config && grep -q "^Host hub\s*" $_USER_HOME/.ssh/config
+    if test -f "$_USER_HOME"/.ssh/config && grep -q "^Host hub\s*" "$_USER_HOME"/.ssh/config
     then
         echo_debug "        ... sshjump host definition found."
     else
         echo_debug "        ... sshjump host definition not found: creating it"
-        cat <<EOT >> $_USER_HOME/.ssh/config
+        cat <<EOT >> "$_USER_HOME"/.ssh/config
 
 # cryptmypi-sshjump-entry-start
 Host hub
@@ -104,9 +104,9 @@ EOT
 
     echo_debug "    Creating/Replacing ${_SSHJUMP_REFERENCE}-sys host definition ..."
     _ENTRYCOMMENT="# cryptmypi-${_SSHJUMP_REFERENCE}-sys-entry"
-    sed -i "/^${_ENTRYCOMMENT}-start/,/^${_ENTRYCOMMENT}-end/{/^${_ENTRYCOMMENT}-start/!{/^${_ENTRYCOMMENT}-end/!d}}" $_USER_HOME/.ssh/config
-    sed -i "/${_ENTRYCOMMENT}/d" $_USER_HOME/.ssh/config
-cat <<EOT >> $_USER_HOME/.ssh/config
+    sed -i "/^${_ENTRYCOMMENT}-start/,/^${_ENTRYCOMMENT}-end/{/^${_ENTRYCOMMENT}-start/!{/^${_ENTRYCOMMENT}-end/!d}}" "$_USER_HOME"/.ssh/config
+    sed -i "/${_ENTRYCOMMENT}/d" "$_USER_HOME"/.ssh/config
+cat <<EOT >> "$_USER_HOME"/.ssh/config
 
 ${_ENTRYCOMMENT}-start
 Host ${_SSHJUMP_REFERENCE}-sys
@@ -120,7 +120,7 @@ ${_ENTRYCOMMENT}-end
 EOT
 
     echo_debug "    Removing unnecessary empty lines"
-    sed -i 'N;/^\n$/D;P;D;' $_USER_HOME/.ssh/config
+    sed -i 'N;/^\n$/D;P;D;' "$_USER_HOME"/.ssh/config
 
 
     echo_debug " ... ${_SSHJUMP_SERVER} channel set up! To connect, use:"

--- a/hooks/0000-experimental-sys-util-rsyncfiles-sshjump.hook
+++ b/hooks/0000-experimental-sys-util-rsyncfiles-sshjump.hook
@@ -21,7 +21,7 @@ mkdir -p "${_SYNC_REMOTEDIR}"
 
 
 echo_debug "Generating script at ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_syncfiles"
-cat <<EOT > ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_syncfiles
+cat <<EOT > "${_CONFDIR}"/sshjump_"${_SSHJUMP_REFERENCE}"_syncfiles
 #!/bin/bash
 
 echo "Stage 1: Local -> Remote Sync"
@@ -31,7 +31,7 @@ echo "Stage 2: Local -> Remote Sync"
 rsync -avzru -e 'ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -i "${_SSH_LOCAL_KEYFILE}" -J ${_SSHJUMP_USERNAME}@${_SSHJUMP_SERVER} -p ${_SSHJUMP_SSH_PORT}' --progress root@${_SSHJUMP_REFERENCE}:${_SYNC_REMOTEDIR}/* ${_SYNC_LOCALDIR}
 
 EOT
-chmod +x ${_CONFDIR}/sshjump_${_SSHJUMP_REFERENCE}_syncfiles
+chmod +x "${_CONFDIR}"/sshjump_"${_SSHJUMP_REFERENCE}"_syncfiles
 
 
 echo_debug " ... rsync script created."

--- a/hooks/0000-optional-initramfs-luksnuke.hook
+++ b/hooks/0000-optional-initramfs-luksnuke.hook
@@ -6,7 +6,7 @@ set -e
 if [ ! -z "${_LUKSNUKEPASSWD}" ]; then
     echo_debug "Attempting to install and configure encrypted pi cryptsetup nuke password."
     chroot_pkginstall cryptsetup-nuke-password
-    chroot ${CHROOTDIR} /bin/bash -c "debconf-set-selections <<END
+    chroot "${CHROOTDIR}" /bin/bash -c "debconf-set-selections <<END
 cryptsetup-nuke-password cryptsetup-nuke-password/password string ${_LUKSNUKEPASSWD}
 cryptsetup-nuke-password cryptsetup-nuke-password/password-again string ${_LUKSNUKEPASSWD}
 END"

--- a/hooks/0000-optional-initramfs-sshhub.hook
+++ b/hooks/0000-optional-initramfs-sshhub.hook
@@ -35,9 +35,9 @@ else
     _SSHHUB_ADDRESS="sshhub.de"
     echo_debug "Registering box keyfile to sshhub (${_SSHHUB_ADDRESS})"
     if [ -z "${_SSHHUB_LOCAL_KEYFILE}" ]; then
-        ssh "${_SSHHUB_USERNAME}@${_SSHHUB_ADDRESS}" pubkey add $(cat "${_KEYFILE}.pub")
+        ssh "${_SSHHUB_USERNAME}@${_SSHHUB_ADDRESS}" pubkey add "$(cat "${_KEYFILE}.pub")"
     else
-        ssh -i "${_SSHHUB_LOCAL_KEYFILE}" "${_SSHHUB_USERNAME}@${_SSHHUB_ADDRESS}" pubkey add $(cat "${_KEYFILE}.pub")
+        ssh -i "${_SSHHUB_LOCAL_KEYFILE}" "${_SSHHUB_USERNAME}@${_SSHHUB_ADDRESS}" pubkey add "$(cat "${_KEYFILE}.pub")"
     fi
 
 
@@ -51,7 +51,7 @@ else
 
 
     echo_debug "Creating initramfs script sshhub_tunnel"
-    cat <<EOT > ${CHROOTDIR}/etc/initramfs-tools/scripts/local-top/sshhub_tunnel
+    cat <<EOT > "${CHROOTDIR}"/etc/initramfs-tools/scripts/local-top/sshhub_tunnel
 #!/bin/sh
 
 PREREQ=""
@@ -78,7 +78,7 @@ EOT
 
 
     echo_debug "Creating sshhub_tunnel.sh connection loop"
-    cat <<EOT > ${CHROOTDIR}/etc/initramfs-tools/ssh_tunnel.sh
+    cat <<EOT > "${CHROOTDIR}"/etc/initramfs-tools/ssh_tunnel.sh
 # !/bin/sh
 
 _SSHHUB_HOST="${_SSHHUB_ADDRESS}"
@@ -96,7 +96,7 @@ EOT
 
 
     echo_debug "Creating initramfs hook sshhub_tunnel"
-    cat <<EOT > ${CHROOTDIR}/etc/initramfs-tools/hooks/sshhub_tunnel
+    cat <<EOT > "${CHROOTDIR}"/etc/initramfs-tools/hooks/sshhub_tunnel
 # !/bin/sh
 set -e
 
@@ -133,12 +133,12 @@ EOT
     echo_debug "Converting id_rsa to a dropbear key dropbear-id_rsa"
     cp "${_KEYFILE}" "${CHROOTDIR}/etc/initramfs-tools/id_rsa.tmp"
     ssh-keygen -m PEM -p -f "${CHROOTDIR}/etc/initramfs-tools/id_rsa.tmp" -q -N ""
-    chroot ${CHROOTDIR} /bin/bash -c "/usr/lib/dropbear/dropbearconvert openssh dropbear /etc/initramfs-tools/id_rsa.tmp /etc/initramfs-tools/dropbear-id_rsa"
+    chroot "${CHROOTDIR}" /bin/bash -c "/usr/lib/dropbear/dropbearconvert openssh dropbear /etc/initramfs-tools/id_rsa.tmp /etc/initramfs-tools/dropbear-id_rsa"
     rm "${CHROOTDIR}/etc/initramfs-tools/id_rsa.tmp"
 
 
     echo_debug "Creating initramfs script kill_sshhub"
-    cat <<EOT > ${CHROOTDIR}/etc/initramfs-tools/scripts/local-bottom/kill_sshhub
+    cat <<EOT > "${CHROOTDIR}"/etc/initramfs-tools/scripts/local-bottom/kill_sshhub
 #!/bin/sh
 
 PREREQ=""
@@ -164,22 +164,22 @@ EOT
 
 
     echo_debug "Creating script to remove this key from SSHHUB: ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_remove"
-    cat <<EOT > ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_remove
+    cat <<EOT > "${_CONFDIR}"/sshhub_"${_SSHHUB_REFERENCE}"_remove
 #!/bin/bash
 cat ${_KEYFILE}.pub | ssh ${_SSHHUB_USERNAME}@sshhub.de pubkey rm
 EOT
-    chmod +x ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_remove
+    chmod +x "${_CONFDIR}"/sshhub_"${_SSHHUB_REFERENCE}"_remove
 
 
     echo_debug "Editing ~/.ssh/config"
 
     echo_debug "    Verifying if sshhub hub alias exists in $_USER_HOME/.ssh/config ..."
-    if test -f $_USER_HOME/.ssh/config && grep -q "^Host hub\s*" $_USER_HOME/.ssh/config
+    if test -f "$_USER_HOME"/.ssh/config && grep -q "^Host hub\s*" "$_USER_HOME"/.ssh/config
     then
         echo_debug "        ... sshhub host definition found."
     else
         echo_debug "        ... sshhub host definition not found: creating it"
-        cat <<EOT >> $_USER_HOME/.ssh/config
+        cat <<EOT >> "$_USER_HOME"/.ssh/config
 
 # cryptmypi-sshhub-entry-start
 Host hub
@@ -192,9 +192,9 @@ EOT
 
     echo_debug "    Creating/Replacing ${_SSHHUB_REFERENCE}-boot host definition ..."
     _ENTRYCOMMENT="# cryptmypi-${_SSHHUB_REFERENCE}-boot-entry"
-    sed -i "/^${_ENTRYCOMMENT}-start/,/^${_ENTRYCOMMENT}-end/{/^${_ENTRYCOMMENT}-start/!{/^${_ENTRYCOMMENT}-end/!d}}" $_USER_HOME/.ssh/config
-    sed -i "/${_ENTRYCOMMENT}/d" $_USER_HOME/.ssh/config
-cat <<EOT >> $_USER_HOME/.ssh/config
+    sed -i "/^${_ENTRYCOMMENT}-start/,/^${_ENTRYCOMMENT}-end/{/^${_ENTRYCOMMENT}-start/!{/^${_ENTRYCOMMENT}-end/!d}}" "$_USER_HOME"/.ssh/config
+    sed -i "/${_ENTRYCOMMENT}/d" "$_USER_HOME"/.ssh/config
+cat <<EOT >> "$_USER_HOME"/.ssh/config
 
 ${_ENTRYCOMMENT}-start
 Host ${_SSHHUB_REFERENCE}-boot
@@ -207,7 +207,7 @@ ${_ENTRYCOMMENT}-end
 EOT
 
     echo_debug "    Removing unnecessary empty lines"
-    sed -i 'N;/^\n$/D;P;D;' $_USER_HOME/.ssh/config
+    sed -i 'N;/^\n$/D;P;D;' "$_USER_HOME"/.ssh/config
 
 
     echo_debug " ... sshhub.de INITRAMFS SSH channel set up! To connect, use:"

--- a/hooks/0000-optional-sys-cpugovernor-ondemand.hook
+++ b/hooks/0000-optional-sys-cpugovernor-ondemand.hook
@@ -5,9 +5,9 @@ set -e
 echo_debug "Attempting to configure 'ondemand cpu governor'"
 echo_debug "    ( Disabled using shift key during boot )"
 echo_debug "    Downloading files"
-lazy_download 'https://github.com/Re4son/RPi-Tweaks/raw/master/cpu-governor/cpu-governor' ${CHROOTDIR}/etc/init.d/cpu-governor
-chroot_execute chmod +x ${CHROOTDIR}/etc/init.d/cpu-governor
-lazy_download 'https://github.com/Re4son/RPi-Tweaks/raw/master/cpu-governor/cpu-governor.service' ${CHROOTDIR}/lib/systemd/system/cpu-governor.service
+lazy_download 'https://github.com/Re4son/RPi-Tweaks/raw/master/cpu-governor/cpu-governor' "${CHROOTDIR}"/etc/init.d/cpu-governor
+chroot_execute chmod +x "${CHROOTDIR}"/etc/init.d/cpu-governor
+lazy_download 'https://github.com/Re4son/RPi-Tweaks/raw/master/cpu-governor/cpu-governor.service' "${CHROOTDIR}"/lib/systemd/system/cpu-governor.service
 
 
 echo_debug "    Installing packages ..."

--- a/hooks/0000-optional-sys-dns.hook
+++ b/hooks/0000-optional-sys-dns.hook
@@ -6,12 +6,12 @@ echo_debug "Attempting to set system's DNS settings..."
 
 
 echo_debug "Writing /etc/resolv.conf ..."
-cat <<EOT > ${CHROOTDIR}/etc/resolv.conf
+cat <<EOT > "${CHROOTDIR}"/etc/resolv.conf
 # DNS (by optional-sys-dns)
 nameserver ${_DNS1}
 nameserver ${_DNS2}
 EOT
-chmod o+r ${CHROOTDIR}/etc/resolv.conf
+chmod o+r "${CHROOTDIR}"/etc/resolv.conf
 
 
 #echo_debug "Installing resolvconf"
@@ -27,7 +27,7 @@ chmod o+r ${CHROOTDIR}/etc/resolv.conf
 
 
 echo_debug "Updating /etc/network/interfaces"
-cat <<EOT >> ${CHROOTDIR}/etc/network/interfaces
+cat <<EOT >> "${CHROOTDIR}"/etc/network/interfaces
 
 # DNS (by optional-sys-dns)
 dns-nameservers ${_DNS1} ${_DNS2}
@@ -37,7 +37,7 @@ EOT
 
 test -e "${CHROOTDIR}/etc/dhclient.conf" && {
     echo_debug "Updating /etc/dhclient.conf"
-    cat <<EOT >> ${CHROOTDIR}/etc/dhclient.conf
+    cat <<EOT >> "${CHROOTDIR}"/etc/dhclient.conf
 
 # DNS (by optional-sys-dns)
 supersede domain-name-servers ${_DNS1}, ${_DNS2};
@@ -47,7 +47,7 @@ EOT
 
 test -e "${CHROOTDIR}/etc/dhpc/dhclient.conf" && {
     echo_debug "Updating /etc/dhpc/dhclient.conf"
-    cat <<EOT >> ${CHROOTDIR}/etc/dhpc/dhclient.conf
+    cat <<EOT >> "${CHROOTDIR}"/etc/dhpc/dhclient.conf
 
 # DNS (by optional-sys-dns)
 supersede domain-name-servers ${_DNS1}, ${_DNS2};

--- a/hooks/0000-optional-sys-docker.hook
+++ b/hooks/0000-optional-sys-docker.hook
@@ -19,7 +19,7 @@ echo_debug "    Updating /boot/cmdline.txt to enable cgroup ..."
 #       cgroup_enable works on kernel 4.9 upwards
 #       cgroup_memory will be dropped in 4.14, but works on < 4.9
 #       keeping both for now
-sed -i "s#rootwait#cgroup_enable=memory cgroup_memory=1 rootwait#g" ${CHROOTDIR}/boot/cmdline.txt
+sed -i "s#rootwait#cgroup_enable=memory cgroup_memory=1 rootwait#g" "${CHROOTDIR}"/boot/cmdline.txt
 
 
 echo_debug "    Updating iptables ... (issue: default kali iptables was stalling)"

--- a/hooks/0000-optional-sys-rootpassword.hook
+++ b/hooks/0000-optional-sys-rootpassword.hook
@@ -4,7 +4,7 @@ set -e
 
 if [ ! -z "${_ROOTPASSWD}" ]; then
     echo_debug "Attempting to change root password."
-    chroot ${CHROOTDIR} /bin/bash -c "echo root:${_ROOTPASSWD} | /usr/sbin/chpasswd"
+    chroot "${CHROOTDIR}" /bin/bash -c "echo root:${_ROOTPASSWD} | /usr/sbin/chpasswd"
 else
     echo_warn "SKIPPING: Root password will not be set. _ROOTPASSWD empty or not set."
 fi

--- a/hooks/0000-optional-sys-sshhub.hook
+++ b/hooks/0000-optional-sys-sshhub.hook
@@ -28,19 +28,19 @@ else
 
     echo_debug "Registering box keyfile to sshhub"
     if [ -z "${_SSHHUB_LOCAL_KEYFILE}" ]; then
-        ssh "${_SSHHUB_USERNAME}@sshhub.de" pubkey add $(cat "${_KEYFILE}.pub")
+        ssh "${_SSHHUB_USERNAME}@sshhub.de" pubkey add "$(cat "${_KEYFILE}.pub")"
     else
-        ssh -i "${_SSHHUB_LOCAL_KEYFILE}" "${_SSHHUB_USERNAME}@sshhub.de" pubkey add $(cat "${_KEYFILE}.pub")
+        ssh -i "${_SSHHUB_LOCAL_KEYFILE}" "${_SSHHUB_USERNAME}@sshhub.de" pubkey add "$(cat "${_KEYFILE}.pub")"
     fi
 
 
     echo_debug "Adding sshhub.de pub key to known_hosts..."
-    ssh-keyscan -H sshhub.de >> ${CHROOTDIR}/root/.ssh/known_hosts
-    chmod 644 ${CHROOTDIR}/root/.ssh/known_hosts
+    ssh-keyscan -H sshhub.de >> "${CHROOTDIR}"/root/.ssh/known_hosts
+    chmod 644 "${CHROOTDIR}"/root/.ssh/known_hosts
 
 
     echo_debug "Creating script to create and maintain sshhub channel..."
-    cat <<EOT > ${CHROOTDIR}/opt/sys-sshhub-channel.sh
+    cat <<EOT > "${CHROOTDIR}"/opt/sys-sshhub-channel.sh
 #!/bin/bash
 
 while true
@@ -55,11 +55,11 @@ do
     }
 done
 EOT
-    chmod +x ${CHROOTDIR}/opt/sys-sshhub-channel.sh
+    chmod +x "${CHROOTDIR}"/opt/sys-sshhub-channel.sh
 
 
     echo_debug "Creating startup service"
-    cat <<EOT > ${CHROOTDIR}/etc/systemd/system/sshhub.service
+    cat <<EOT > "${CHROOTDIR}"/etc/systemd/system/sshhub.service
 [Unit]
 Description=sshhub
 
@@ -74,22 +74,22 @@ EOT
 
 
     echo_debug "Creating script to remove this key from SSHHUB: ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_remove"
-    cat <<EOT > ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_remove
+    cat <<EOT > "${_CONFDIR}"/sshhub_"${_SSHHUB_REFERENCE}"_remove
 #!/bin/bash
 cat ${_KEYFILE}.pub | ssh ${_SSHHUB_USERNAME}@sshhub.de pubkey rm
 EOT
-    chmod +x ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_remove
+    chmod +x "${_CONFDIR}"/sshhub_"${_SSHHUB_REFERENCE}"_remove
 
 
     echo_debug "Editing ~/.ssh/config"
 
     echo_debug "    Verifying if sshhub hub alias exists in $_USER_HOME/.ssh/config ..."
-    if test -f $_USER_HOME/.ssh/config && grep -q "^Host hub\s*" $_USER_HOME/.ssh/config
+    if test -f "$_USER_HOME"/.ssh/config && grep -q "^Host hub\s*" "$_USER_HOME"/.ssh/config
     then
         echo_debug "        ... sshhub host definition found."
     else
         echo_debug "        ... sshhub host definition not found: creating it"
-        cat <<EOT >> $_USER_HOME/.ssh/config
+        cat <<EOT >> "$_USER_HOME"/.ssh/config
 
 # cryptmypi-sshhub-entry-start
 Host hub
@@ -102,9 +102,9 @@ EOT
 
     echo_debug "    Creating/Replacing ${_SSHHUB_REFERENCE}-sys host definition ..."
     _ENTRYCOMMENT="# cryptmypi-${_SSHHUB_REFERENCE}-sys-entry"
-    sed -i "/^${_ENTRYCOMMENT}-start/,/^${_ENTRYCOMMENT}-end/{/^${_ENTRYCOMMENT}-start/!{/^${_ENTRYCOMMENT}-end/!d}}" $_USER_HOME/.ssh/config
-    sed -i "/${_ENTRYCOMMENT}/d" $_USER_HOME/.ssh/config
-cat <<EOT >> $_USER_HOME/.ssh/config
+    sed -i "/^${_ENTRYCOMMENT}-start/,/^${_ENTRYCOMMENT}-end/{/^${_ENTRYCOMMENT}-start/!{/^${_ENTRYCOMMENT}-end/!d}}" "$_USER_HOME"/.ssh/config
+    sed -i "/${_ENTRYCOMMENT}/d" "$_USER_HOME"/.ssh/config
+cat <<EOT >> "$_USER_HOME"/.ssh/config
 
 ${_ENTRYCOMMENT}-start
 Host ${_SSHHUB_REFERENCE}-sys
@@ -118,7 +118,7 @@ ${_ENTRYCOMMENT}-end
 EOT
 
     echo_debug "    Removing unnecessary empty lines"
-    sed -i 'N;/^\n$/D;P;D;' $_USER_HOME/.ssh/config
+    sed -i 'N;/^\n$/D;P;D;' "$_USER_HOME"/.ssh/config
 
 
     echo_debug " ... sshhub.de channel set up! To connect, use:"

--- a/hooks/0000-optional-sys-util-rsyncfiles-sshhub.hook
+++ b/hooks/0000-optional-sys-util-rsyncfiles-sshhub.hook
@@ -21,7 +21,7 @@ mkdir -p "${_SYNC_REMOTEDIR}"
 
 
 echo_debug "Generating script at ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_syncfiles"
-cat <<EOT > ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_syncfiles
+cat <<EOT > "${_CONFDIR}"/sshhub_"${_SSHHUB_REFERENCE}"_syncfiles
 #!/bin/bash
 
 echo "Stage 1: Local -> Remote Sync"
@@ -31,7 +31,7 @@ echo "Stage 2: Local -> Remote Sync"
 rsync -avzru -e 'ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -i "${_SSH_LOCAL_KEYFILE}" -J ${_SSHHUB_USERNAME}@sshhub.de -p ${_SSHHUB_SSH_PORT}' --progress root@${_SSHHUB_REFERENCE}:${_SYNC_REMOTEDIR}/* ${_SYNC_LOCALDIR}
 
 EOT
-chmod +x ${_CONFDIR}/sshhub_${_SSHHUB_REFERENCE}_syncfiles
+chmod +x "${_CONFDIR}"/sshhub_"${_SSHHUB_REFERENCE}"_syncfiles
 
 
 echo_debug " ... rsync script created."

--- a/hooks/0000-optional-sys-vpnclient.hook
+++ b/hooks/0000-optional-sys-vpnclient.hook
@@ -8,17 +8,17 @@ _OPENVPN_CONFIG_ZIPPATH="${_CONFDIR}/${_OPENVPN_CONFIG_ZIPFILE}"
 
 
 echo_debug "Setting OpenVPN up ..."
-if [ -f ${_OPENVPN_CONFIG_ZIPPATH} ]; then
+if [ -f "${_OPENVPN_CONFIG_ZIPPATH}" ]; then
     echo_debug "Assuring openvpn installation and config dir"
     chroot_pkginstall openvpn
-    mkdir -p ${CHROOTDIR}/etc/openvpn
+    mkdir -p "${CHROOTDIR}"/etc/openvpn
 
     echo_debug "Unzipping provided files into configuration dir"
-    unzip ${_OPENVPN_CONFIG_ZIPPATH} -d ${CHROOTDIR}/etc/openvpn/
+    unzip "${_OPENVPN_CONFIG_ZIPPATH}" -d "${CHROOTDIR}"/etc/openvpn/
 
     echo_debug "Setting AUTOSTART to ALL on OPENVPN config"
-    sed -i '/^AUTOSTART=/s/^/#/' ${CHROOTDIR}/etc/default/openvpn
-    sed -i '/^#AUTOSTART="all"/s/^#//' ${CHROOTDIR}/etc/default/openvpn
+    sed -i '/^AUTOSTART=/s/^/#/' "${CHROOTDIR}"/etc/default/openvpn
+    sed -i '/^#AUTOSTART="all"/s/^#//' "${CHROOTDIR}"/etc/default/openvpn
 
     echo_debug "Enabling service ..."
     chroot_execute systemctl enable openvpn@client

--- a/hooks/0000-optional-sys-wifi.hook
+++ b/hooks/0000-optional-sys-wifi.hook
@@ -17,7 +17,7 @@ _WIFI_PSK=$(wpa_passphrase "${_WIFI_SSID}" "${_WIFI_PASS}" | grep "psk=" | grep 
 
 
 echo_debug "Creating wpa_supplicant file"
-cat <<EOT > ${CHROOTDIR}/etc/wpa_supplicant.conf
+cat <<EOT > "${CHROOTDIR}"/etc/wpa_supplicant.conf
 ctrl_interface=/var/run/wpa_supplicant
 network={
        ssid="${_WIFI_SSID}"
@@ -32,7 +32,7 @@ EOT
 
 
 echo_debug "Updating /etc/network/interfaces file"
-cat <<EOT >> ${CHROOTDIR}/etc/network/interfaces
+cat <<EOT >> "${CHROOTDIR}"/etc/network/interfaces
 
 # The buildin wireless interface
 auto ${_WIFI_INTERFACE}
@@ -46,7 +46,7 @@ EOT
 
 
 echo_debug "Create connection script /root/sys-wifi-connect.sh"
-cat <<EOT >> ${CHROOTDIR}/root/sys-wifi-connect.sh
+cat <<EOT >> "${CHROOTDIR}"/root/sys-wifi-connect.sh
 #!/bin/bash
 
 # Remove file if exists
@@ -62,7 +62,7 @@ wpa_supplicant -B -Dwext -i ${_WIFI_INTERFACE} -c /etc/wpa_supplicant.conf
 # Get IP from dhcp
 # dhclient ${_WIFI_INTERFACE}
 EOT
-chmod +x ${CHROOTDIR}/root/sys-wifi-connect.sh
+chmod +x "${CHROOTDIR}"/root/sys-wifi-connect.sh
 
 
 #echo_debug "Add to cron to start at boot (before login)"

--- a/hooks/2000-stage1-image-download.hook
+++ b/hooks/2000-stage1-image-download.hook
@@ -2,11 +2,11 @@
 set -e
 
 # Download ARM image if we don't already have it
-if [ -f ${_IMAGEDIR}/${_IMAGENAME} ]; then
+if [ -f "${_IMAGEDIR}"/"${_IMAGENAME}" ]; then
     echo_debug "ARM image ${_IMAGENAME} already exists!"
 else
     echo_debug "Downloading ARM image from ${_IMAGEURL} ..."
-    wget ${_IMAGEURL} -O ${_IMAGEDIR}/${_IMAGENAME}
+    wget "${_IMAGEURL}" -O "${_IMAGEDIR}"/"${_IMAGENAME}"
 fi
 
 # Validates image
@@ -19,7 +19,7 @@ else
     } || {
         echo_error "ERROR: ${_IMAGENAME} checksum is not valid ..."
         echo_error "Removing ${_IMAGENAME} ..."
-        rm ${_IMAGEDIR}/${_IMAGENAME}
+        rm "${_IMAGEDIR}"/"${_IMAGENAME}"
         echo_error "Exiting ..."
         exit 1
     }

--- a/hooks/2100-stage1-image-extract.hook
+++ b/hooks/2100-stage1-image-extract.hook
@@ -3,16 +3,16 @@ set -e
 
 
 # Extract files from image
-mkdir ${_BUILDDIR}/root
-mkdir ${_BUILDDIR}/mount
+mkdir "${_BUILDDIR}"/root
+mkdir "${_BUILDDIR}"/mount
 
 echo_debug "Extracting image: ${_IMAGENAME} ..."
 case ${_IMAGENAME} in
     *.xz)
-        xz --decompress --stdout ${_IMAGEDIR}/${_IMAGENAME} > ${_BUILDDIR}/cryptmypi.img
+        xz --decompress --stdout "${_IMAGEDIR}"/"${_IMAGENAME}" > "${_BUILDDIR}"/cryptmypi.img
         ;;
     *.zip)
-        unzip -p ${_IMAGEDIR}/${_IMAGENAME} > ${_BUILDDIR}/cryptmypi.img
+        unzip -p "${_IMAGEDIR}"/"${_IMAGENAME}" > "${_BUILDDIR}"/cryptmypi.img
         ;;
     *)
         echo_error "Unknown extension type on image: ${_IMAGENAME} ! Stopping here."
@@ -22,27 +22,27 @@ esac
 
 
 echo_debug "Mounting loopback ..."
-loopdev=$(losetup -f --show ${_BUILDDIR}/cryptmypi.img)
-partprobe ${loopdev}
+loopdev=$(losetup -f --show "${_BUILDDIR}"/cryptmypi.img)
+partprobe "${loopdev}"
 
 
 # Extract root partition
-mount ${loopdev}p2 ${_BUILDDIR}/mount
+mount "${loopdev}"p2 "${_BUILDDIR}"/mount
 
 echo_debug "Syncing image/root to ${_BUILDDIR}/root ..."
-rsync -HPavz -q ${_BUILDDIR}/mount/ ${_BUILDDIR}/root/
-umount ${_BUILDDIR}/mount
+rsync -HPavz -q "${_BUILDDIR}"/mount/ "${_BUILDDIR}"/root/
+umount "${_BUILDDIR}"/mount
 
 
 # Extract boot partition
-mount ${loopdev}p1 ${_BUILDDIR}/mount/
+mount "${loopdev}"p1 "${_BUILDDIR}"/mount/
 echo_debug "Syncing image/root/boot to ${_BUILDDIR}/root/boot ..."
-rsync -HPavz -q ${_BUILDDIR}/mount/ ${_BUILDDIR}/root/boot/
-umount ${_BUILDDIR}/mount
+rsync -HPavz -q "${_BUILDDIR}"/mount/ "${_BUILDDIR}"/root/boot/
+umount "${_BUILDDIR}"/mount
 
 
 # Clear loopback
-rmdir ${_BUILDDIR}/mount
+rmdir "${_BUILDDIR}"/mount
 echo_debug "Cleaning loopback ..."
-losetup -d ${loopdev}
-rm ${_BUILDDIR}/cryptmypi.img
+losetup -d "${loopdev}"
+rm "${_BUILDDIR}"/cryptmypi.img

--- a/hooks/2200-stage1-setup-chroot.hook
+++ b/hooks/2200-stage1-setup-chroot.hook
@@ -4,8 +4,8 @@ set -e
 
 # Setup qemu emulator for aarch64
 echo_debug "- Copying qemu emulator to chroot ..."
-cp /usr/bin/qemu-aarch64-static ${_BUILDDIR}/root/usr/bin/
+cp /usr/bin/qemu-aarch64-static "${_BUILDDIR}"/root/usr/bin/
 
 
-chroot_mount ${_BUILDDIR}/root
+chroot_mount "${_BUILDDIR}"/root
 chroot_update

--- a/hooks/2300-stage1-locale.hook
+++ b/hooks/2300-stage1-locale.hook
@@ -12,11 +12,11 @@ fi
 
 
 echo_debug "Uncommenting locale '${_LOCALE}' for inclusion in generation"
-sed -i 's/^# *\(en_US.UTF-8\)/\1/' ${CHROOTDIR}/etc/locale.gen
+sed -i 's/^# *\(en_US.UTF-8\)/\1/' "${CHROOTDIR}"/etc/locale.gen
 
 
 echo_debug "Updating /etc/default/locale"
-cat << EOF >> ${CHROOTDIR}/etc/default/locale
+cat << EOF >> "${CHROOTDIR}"/etc/default/locale
 LANG=${_LOCALE}
 EOF
 
@@ -26,7 +26,7 @@ chroot_pkginstall locales
 
 
 echo_debug "Updating env variables"
-chroot ${CHROOTDIR} /bin/bash -x <<EOF
+chroot "${CHROOTDIR}" /bin/bash -x <<EOF
 export LC_ALL="${_LOCALE}" 2> /dev/null
 export LANG="${_LOCALE}"
 export LANGUAGE="${_LOCALE}"
@@ -38,7 +38,7 @@ chroot_execute locale-gen
 
 
 echo_debug "Updating .bashrc"
-cat << EOF >> ${CHROOTDIR}/root/.bashrc
+cat << EOF >> "${CHROOTDIR}"/root/.bashrc
 
 # Setting locales
 export LC_ALL="${_LOCALE}"

--- a/hooks/2700-stage1-dropbear.hook
+++ b/hooks/2700-stage1-dropbear.hook
@@ -41,31 +41,31 @@ fi
 EOF
 
 # Adding command to authorized keys
-cat << "EOF" > ${CHROOTDIR}/etc/dropbear-initramfs/authorized_keys.tmp
+cat << "EOF" > "${CHROOTDIR}"/etc/dropbear-initramfs/authorized_keys.tmp
 command="/etc/unlock.sh; exit" 
 EOF
 #command="export PATH='/sbin:/bin/:/usr/sbin:/usr/bin'; cryptsetup luksOpen /dev/mmcblk0p2 crypt && /scripts/local-top/cryptroot || reboot -f;  for i in $(ps aux | grep cryptroot | awk '{print $1}'); do kill -9 $i; done; for i in $(ps aux | grep askpass | awk '{print $1}'); do kill -9 $i; done; exit" 
-tr -d '\n' < ${CHROOTDIR}/etc/dropbear-initramfs/authorized_keys.tmp > ${CHROOTDIR}/etc/dropbear-initramfs/authorized_keys
-rm -f ${CHROOTDIR}/etc/dropbear-initramfs/authorized_keys.tmp
+tr -d '\n' < "${CHROOTDIR}"/etc/dropbear-initramfs/authorized_keys.tmp > "${CHROOTDIR}"/etc/dropbear-initramfs/authorized_keys
+rm -f "${CHROOTDIR}"/etc/dropbear-initramfs/authorized_keys.tmp
 
 
 # Now append our key to dropbear authorized_keys file
-cat "${_SSH_LOCAL_KEYFILE}.pub" >> ${CHROOTDIR}/etc/dropbear-initramfs/authorized_keys
-chmod 600 ${CHROOTDIR}/etc/dropbear-initramfs/authorized_keys
+cat "${_SSH_LOCAL_KEYFILE}.pub" >> "${CHROOTDIR}"/etc/dropbear-initramfs/authorized_keys
+chmod 600 "${CHROOTDIR}"/etc/dropbear-initramfs/authorized_keys
 
 
 # Update dropbear for some sleep in initramfs
-sed -i 's/run_dropbear &/sleep 5\nrun_dropbear &/g' ${CHROOTDIR}/usr/share/initramfs-tools/scripts/init-premount/dropbear
+sed -i 's/run_dropbear &/sleep 5\nrun_dropbear &/g' "${CHROOTDIR}"/usr/share/initramfs-tools/scripts/init-premount/dropbear
 
 
 # Change the port that dropbear runs on to make our lives easier
-sed -i 's/#DROPBEAR_OPTIONS=/DROPBEAR_OPTIONS="-p 2222"/g' ${CHROOTDIR}/etc/dropbear-initramfs/config
+sed -i 's/#DROPBEAR_OPTIONS=/DROPBEAR_OPTIONS="-p 2222"/g' "${CHROOTDIR}"/etc/dropbear-initramfs/config
 
 
 # Using provided dropbear keys (or backuping generating ones for later usage)
-backup_and_use_sshkey ${CHROOTDIR}/etc/dropbear-initramfs/dropbear_dss_host_key
-backup_and_use_sshkey ${CHROOTDIR}/etc/dropbear-initramfs/dropbear_ecdsa_host_key
-backup_and_use_sshkey ${CHROOTDIR}/etc/dropbear-initramfs/dropbear_rsa_host_key
+backup_and_use_sshkey "${CHROOTDIR}"/etc/dropbear-initramfs/dropbear_dss_host_key
+backup_and_use_sshkey "${CHROOTDIR}"/etc/dropbear-initramfs/dropbear_ecdsa_host_key
+backup_and_use_sshkey "${CHROOTDIR}"/etc/dropbear-initramfs/dropbear_rsa_host_key
 
 
 echo_debug "... dropbearpi call completed!"

--- a/hooks/3000-stage1-setup-encryption.hook
+++ b/hooks/3000-stage1-setup-encryption.hook
@@ -5,34 +5,34 @@ set -e
 chroot_pkginstall cryptsetup cryptsetup-initramfs busybox
 
 # Creating symbolic link to e2fsck
-chroot ${_BUILDDIR}/root /bin/bash -c "test -L /sbin/fsck.luks || ln -s /sbin/e2fsck /sbin/fsck.luks"
+chroot "${_BUILDDIR}"/root /bin/bash -c "test -L /sbin/fsck.luks || ln -s /sbin/e2fsck /sbin/fsck.luks"
 
 # Indicate kernel to use initramfs (facilitates loading drivers)
-echo "initramfs initramfs.gz followkernel" >> ${_BUILDDIR}/root/boot/config.txt
+echo "initramfs initramfs.gz followkernel" >> "${_BUILDDIR}"/root/boot/config.txt
 
 # Begin cryptsetup
 echo_debug "Making the cryptsetup settings ..."
 
 # Generate a uuid for luks
 __LUKSUUID=$(cat /proc/sys/kernel/random/uuid)
-echo "__LUKSUUID=${__LUKSUUID}" > ${_BUILDDIR}/root/boot/luksuuid.txt
+echo "__LUKSUUID=${__LUKSUUID}" > "${_BUILDDIR}"/root/boot/luksuuid.txt
 
 # Update /boot/cmdline.txt to boot crypt
-sed -i 's#root=/dev/mmcblk0p2#root=/dev/mapper/crypt#g' ${_BUILDDIR}/root/boot/cmdline.txt
-sed -i 's#rootfstype=ext3#rootfstype=ext4#g' ${_BUILDDIR}/root/boot/cmdline.txt
+sed -i 's#root=/dev/mmcblk0p2#root=/dev/mapper/crypt#g' "${_BUILDDIR}"/root/boot/cmdline.txt
+sed -i 's#rootfstype=ext3#rootfstype=ext4#g' "${_BUILDDIR}"/root/boot/cmdline.txt
 
 # Enable cryptsetup when building initramfs
-echo "CRYPTSETUP=y" >> ${_BUILDDIR}/root/etc/cryptsetup-initramfs/conf-hook
+echo "CRYPTSETUP=y" >> "${_BUILDDIR}"/root/etc/cryptsetup-initramfs/conf-hook
 
 # Update /etc/fstab
-sed -i 's#/dev/mmcblk0p2#/dev/mapper/crypt#g' ${_BUILDDIR}/root/etc/fstab
-sed -i 's#ext3#ext4#g' ${_BUILDDIR}/root/etc/fstab
+sed -i 's#/dev/mmcblk0p2#/dev/mapper/crypt#g' "${_BUILDDIR}"/root/etc/fstab
+sed -i 's#ext3#ext4#g' "${_BUILDDIR}"/root/etc/fstab
 
 # Update /etc/crypttab
-echo "crypt    UUID=${__LUKSUUID}    none    luks" > ${_BUILDDIR}/root/etc/crypttab
+echo "crypt    UUID=${__LUKSUUID}    none    luks" > "${_BUILDDIR}"/root/etc/crypttab
 
 # Create a hook to include our crypttab in the initramfs
-cat << EOF > ${_BUILDDIR}/root/etc/initramfs-tools/hooks/zz-cryptsetup
+cat << EOF > "${_BUILDDIR}"/root/etc/initramfs-tools/hooks/zz-cryptsetup
 # !/bin/sh
 set -e
 
@@ -58,7 +58,7 @@ cat /etc/crypttab >> \${DESTDIR}/etc/crypttab
 cat /etc/fstab >> \${DESTDIR}/etc/fstab
 copy_file config /etc/initramfs-tools/unlock.sh /etc/unlock.sh
 EOF
-chmod 755 ${_BUILDDIR}/root/etc/initramfs-tools/hooks/zz-cryptsetup
+chmod 755 "${_BUILDDIR}"/root/etc/initramfs-tools/hooks/zz-cryptsetup
 
 # Unlock Script
 cat << EOF > "${CHROOTDIR}/etc/initramfs-tools/unlock.sh"
@@ -81,4 +81,4 @@ EOF
 chmod +x "${CHROOTDIR}/etc/initramfs-tools/unlock.sh"
 
 # Adding dm_mod to initramfs modules
-echo 'dm_crypt' >> ${_BUILDDIR}/root/etc/initramfs-tools/modules
+echo 'dm_crypt' >> "${_BUILDDIR}"/root/etc/initramfs-tools/modules

--- a/hooks/3200-stage1-otherscript.hook
+++ b/hooks/3200-stage1-otherscript.hook
@@ -18,7 +18,7 @@ test -f "${_STAGE1_OTHERSCRIPT_PATH}" && {
     cp "${_STAGE1_OTHERSCRIPT_PATH}" "${CHROOTDIR}/root/"
     chmod +x "${CHROOTDIR}/root/${_STAGE1_OTHERSCRIPT}"
     echo_debug "## Script execution ############################################################"
-    chroot ${CHROOTDIR} /bin/bash -c "/root/${_STAGE1_OTHERSCRIPT}"
+    chroot "${CHROOTDIR}" /bin/bash -c "/root/${_STAGE1_OTHERSCRIPT}"
     echo_debug "## End of Script execution #####################################################"
     rm "${CHROOTDIR}/root/${_STAGE1_OTHERSCRIPT}"
 } || {

--- a/hooks/5000-stage2-sanity-mounts.hook
+++ b/hooks/5000-stage2-sanity-mounts.hook
@@ -3,7 +3,7 @@ set -e
 
 
 echo_debug "Attempt to unmount just to be safe ..."
-umount ${_BLKDEV}* || true
+umount "${_BLKDEV}"* || true
 umount /mnt/cryptmypi || {
     umount -l /mnt/cryptmypi || true
     umount -f /dev/mapper/crypt || true

--- a/hooks/5100-stage2-setup-partitions.hook
+++ b/hooks/5100-stage2-setup-partitions.hook
@@ -3,8 +3,8 @@ set -e
 
 
 echo_debug "Partitioning SD Card"
-parted ${_BLKDEV} --script -- mklabel msdos
-parted ${_BLKDEV} --script -- mkpart primary fat32 0 256
-parted ${_BLKDEV} --script -- mkpart primary 256 -1
+parted "${_BLKDEV}" --script -- mklabel msdos
+parted "${_BLKDEV}" --script -- mkpart primary fat32 0 256
+parted "${_BLKDEV}" --script -- mkpart primary 256 -1
 sync
 sync

--- a/hooks/5200-stage2-setup-luks-create.hook
+++ b/hooks/5200-stage2-setup-luks-create.hook
@@ -6,28 +6,28 @@ is_build_encrypted && {
     # Create LUKS
     echo_debug "Attempting to create LUKS ${_BLKDEV}${__PARTITIONPREFIX}2 ..."
     if [ ! -z "${_LUKSPASSWD}" ]; then
-        echo "${_LUKSPASSWD}" | cryptsetup -v --cipher ${_LUKSCIPHER} ${_LUKSEXTRA} luksFormat ${_BLKDEV}${__PARTITIONPREFIX}2
+        echo "${_LUKSPASSWD}" | cryptsetup -v --cipher "${_LUKSCIPHER}" "${_LUKSEXTRA}" luksFormat "${_BLKDEV}""${__PARTITIONPREFIX}"2
     else
-        cryptsetup -v -y --cipher ${_LUKSCIPHER} ${_LUKSEXTRA} luksFormat ${_BLKDEV}${__PARTITIONPREFIX}2
+        cryptsetup -v -y --cipher "${_LUKSCIPHER}" "${_LUKSEXTRA}" luksFormat "${_BLKDEV}""${__PARTITIONPREFIX}"2
     fi
     if [ $? -eq 0 ]; then
         echo_debug "- LUKS created."
         ## Source in our UUID
-        . ${_BUILDDIR}/root/boot/luksuuid.txt
+        . "${_BUILDDIR}"/root/boot/luksuuid.txt
         ## Test to generate new luks uuid
         if [ "${_NEWLUKSUUID}" = "yes" ]; then
             echo_debug "Attempting to regenerate and configure a new luks uuid for deployment ..."
             __NEWLUKSUUID=$(cat /proc/sys/kernel/random/uuid)
-            echo "__NEWLUKSUUID=${__NEWLUKSUUID}" > ${_BUILDDIR}/root/boot/newluksuuid.txt
-            echo "crypt    UUID=${__NEWLUKSUUID}    none    luks" > ${_BUILDDIR}/root/etc/crypttab
-            sed -i "s#${__LUKSUUID}#${__NEWLUKSUUID}#g" ${_BUILDDIR}/root/etc/initramfs-tools/unlock.sh
+            echo "__NEWLUKSUUID=${__NEWLUKSUUID}" > "${_BUILDDIR}"/root/boot/newluksuuid.txt
+            echo "crypt    UUID=${__NEWLUKSUUID}    none    luks" > "${_BUILDDIR}"/root/etc/crypttab
+            sed -i "s#${__LUKSUUID}#${__NEWLUKSUUID}#g" "${_BUILDDIR}"/root/etc/initramfs-tools/unlock.sh
             __LUKSUUID="${__NEWLUKSUUID}"
         fi
         echo_debug "Attempting to set the UUID of ${__LUKSUUID} on ${_BLKDEV}${__PARTITIONPREFIX}2 ..."
         if [ ! -z "${_LUKSPASSWD}" ]; then
-            echo "${_LUKSPASSWD}" | cryptsetup -v luksUUID --uuid "${__LUKSUUID}" ${_BLKDEV}${__PARTITIONPREFIX}2
+            echo "${_LUKSPASSWD}" | cryptsetup -v luksUUID --uuid "${__LUKSUUID}" "${_BLKDEV}""${__PARTITIONPREFIX}"2
         else
-            cryptsetup -v luksUUID --uuid "${__LUKSUUID}" ${_BLKDEV}${__PARTITIONPREFIX}2
+            cryptsetup -v luksUUID --uuid "${__LUKSUUID}" "${_BLKDEV}""${__PARTITIONPREFIX}"2
         fi
         if [ $? -eq 0 ]; then
             echo_debug "- LUKS UUID was created."

--- a/hooks/5300-stage2-setup-luks-open.hook
+++ b/hooks/5300-stage2-setup-luks-open.hook
@@ -6,9 +6,9 @@ is_build_encrypted && {
     # Open LUKS
     echo_debug "Attempting to open LUKS ${_BLKDEV}${__PARTITIONPREFIX}2 ..."
     if [ ! -z "${_LUKSPASSWD}" ]; then
-        echo "${_LUKSPASSWD}" | cryptsetup -v luksOpen ${_BLKDEV}${__PARTITIONPREFIX}2 crypt
+        echo "${_LUKSPASSWD}" | cryptsetup -v luksOpen "${_BLKDEV}""${__PARTITIONPREFIX}"2 crypt
     else
-        cryptsetup -v luksOpen ${_BLKDEV}${__PARTITIONPREFIX}2 crypt
+        cryptsetup -v luksOpen "${_BLKDEV}""${__PARTITIONPREFIX}"2 crypt
     fi
     if [ $? -eq 0 ]; then
         echo_debug "- LUKS opened."

--- a/hooks/5400-stage2-setup-format.hook
+++ b/hooks/5400-stage2-setup-format.hook
@@ -16,7 +16,7 @@ is_build_encrypted && {
 } || {
     # Format ROOT partition
     echo_debug "Attempting to format root partition ..."
-    if mkfs.ext4 ${_BLKDEV}${__PARTITIONPREFIX}2
+    if mkfs.ext4 "${_BLKDEV}""${__PARTITIONPREFIX}"2
     then
         echo_debug "- Root partition formatted to ext4."
     else
@@ -29,5 +29,5 @@ is_build_encrypted && {
 
 # Format boot partition
 echo_debug "Formatting Boot Partition"
-mkfs.vfat ${_BLKDEV}${__PARTITIONPREFIX}1
+mkfs.vfat "${_BLKDEV}""${__PARTITIONPREFIX}"1
 echo

--- a/hooks/5500-stage2-setup-mounts.hook
+++ b/hooks/5500-stage2-setup-mounts.hook
@@ -18,7 +18,7 @@ is_build_encrypted && {
     # Mount ext4 formatted ROOT
     echo_debug "Attempting to mount ${_BLKDEV}${__PARTITIONPREFIX}2 to /mnt/cryptmypi ..."
     mkdir /mnt/cryptmypi
-    if mount ${_BLKDEV}${__PARTITIONPREFIX}2 /mnt/cryptmypi
+    if mount "${_BLKDEV}""${__PARTITIONPREFIX}"2 /mnt/cryptmypi
     then
         echo_debug "- Mounted ${_BLKDEV}${__PARTITIONPREFIX}2 to /mnt/cryptmypi"
     else
@@ -32,7 +32,7 @@ is_build_encrypted && {
 # Mount boot partition
 echo_debug "Attempting to mount ${_BLKDEV}${__PARTITIONPREFIX}1 to /mnt/cryptmypi/boot ..."
 mkdir /mnt/cryptmypi/boot
-if mount ${_BLKDEV}${__PARTITIONPREFIX}1 /mnt/cryptmypi/boot
+if mount "${_BLKDEV}""${__PARTITIONPREFIX}"1 /mnt/cryptmypi/boot
 then
     echo_debug "- Mounted ${_BLKDEV}${__PARTITIONPREFIX}1 to /mnt/cryptmypi/boot"
 else

--- a/hooks/7400-stage2-otherscript.hook
+++ b/hooks/7400-stage2-otherscript.hook
@@ -18,7 +18,7 @@ test -f "${_STAGE2_OTHERSCRIPT_PATH}" && {
     cp "${_STAGE2_OTHERSCRIPT_PATH}" "${CHROOTDIR}/root/"
     chmod +x "${CHROOTDIR}/root/${_STAGE2_OTHERSCRIPT}"
     echo_debug "## Script execution ############################################################"
-    chroot ${CHROOTDIR} /bin/bash -c "/root/${_STAGE2_OTHERSCRIPT}"
+    chroot "${CHROOTDIR}" /bin/bash -c "/root/${_STAGE2_OTHERSCRIPT}"
     echo_debug "## End of Script execution #####################################################"
     rm "${CHROOTDIR}/root/${_STAGE2_OTHERSCRIPT}"
 } || {

--- a/hooks/7700-stage2-teardown-mounts.hook
+++ b/hooks/7700-stage2-teardown-mounts.hook
@@ -4,7 +4,7 @@ set -e
 
 # Unmount boot partition
 echo_debug "Attempting to unmount ${_BLKDEV}${__PARTITIONPREFIX}1 ..."
-if umount ${_BLKDEV}${__PARTITIONPREFIX}1
+if umount "${_BLKDEV}""${__PARTITIONPREFIX}"1
 then
     echo_debug "- Unmounted ${_BLKDEV}${__PARTITIONPREFIX}1"
 else

--- a/other/mini-kali-image
+++ b/other/mini-kali-image
@@ -9,29 +9,29 @@ set -e
 #64bit
 ARCH=arm64
 
-mkdir ${_BUILDDIR}/root
+mkdir "${_BUILDDIR}"/root
 
 
 #stage 1 of debootstrap (the part that runs on the host)
-debootstrap --foreign --arch $ARCH --variant=minbase kali-rolling ${_BUILDDIR}/root http://archive.kali.org/kali
+debootstrap --foreign --arch $ARCH --variant=minbase kali-rolling "${_BUILDDIR}"/root http://archive.kali.org/kali
 
 #setup qemu for emulation
-[ "$ARCH" == "armhf" ] && cp /usr/bin/qemu-arm-static ${_BUILDDIR}/root/usr/bin/
-[ "$ARCH" == "arm64" ] && cp /usr/bin/qemu-aarch64-static ${_BUILDDIR}/root/usr/bin/
+[ "$ARCH" == "armhf" ] && cp /usr/bin/qemu-arm-static "${_BUILDDIR}"/root/usr/bin/
+[ "$ARCH" == "arm64" ] && cp /usr/bin/qemu-aarch64-static "${_BUILDDIR}"/root/usr/bin/
 
 #state 2 of debootstrap (the part that is emulated in the chroot)
-LANG=C chroot ${_BUILDDIR}/root /debootstrap/debootstrap --second-stage
+LANG=C chroot "${_BUILDDIR}"/root /debootstrap/debootstrap --second-stage
 
 #get the kali signing key
-wget -q -O - https://archive.kali.org/archive-key.asc | gpg --dearmor > ${_BUILDDIR}/root/etc/apt/trusted.gpg.d/kali-archive-keyring.gpg
+wget -q -O - https://archive.kali.org/archive-key.asc | gpg --dearmor > "${_BUILDDIR}"/root/etc/apt/trusted.gpg.d/kali-archive-keyring.gpg
 
 #add re4son's apt source (for kalipi-* packages and a few others)
-echo "deb http://http.re4son-kernel.com/re4son kali-pi main" > ${_BUILDDIR}/root/etc/apt/sources.list.d/re4son.list
-wget -q -O - https://re4son-kernel.com/keys/http/kali_pi-archive-keyring.gpg > ${_BUILDDIR}/root/etc/apt/trusted.gpg.d/kali_pi-archive-keyring.gpg
+echo "deb http://http.re4son-kernel.com/re4son kali-pi main" > "${_BUILDDIR}"/root/etc/apt/sources.list.d/re4son.list
+wget -q -O - https://re4son-kernel.com/keys/http/kali_pi-archive-keyring.gpg > "${_BUILDDIR}"/root/etc/apt/trusted.gpg.d/kali_pi-archive-keyring.gpg
 
 
 #stage 3 (install some more software)
-cat <<EOF > ${_BUILDDIR}/root/setup.sh
+cat <<EOF > "${_BUILDDIR}"/root/setup.sh
 export DEBIAN_FRONTEND=noninteractive
 #pre answer some questions
 echo "keyboard-configuration keyboard-configuration/layout select English (US)" | debconf-set-selections
@@ -41,18 +41,18 @@ apt -y install initramfs-tools kalipi-kernel kalipi-bootloader kalipi-re4son-fir
 apt -y install binutils ca-certificates console-common console-setup locales libterm-readline-gnu-perl locales-all
 apt -y install ssh network-manager iproute2 iputils-ping nano vim net-tools git wget curl
 EOF
-chmod a+x ${_BUILDDIR}/root/setup.sh
-LANG=C chroot ${_BUILDDIR}/root /setup.sh
+chmod a+x "${_BUILDDIR}"/root/setup.sh
+LANG=C chroot "${_BUILDDIR}"/root /setup.sh
 
 #cmdline.txt
-cat <<EOF > ${_BUILDDIR}/root/boot/cmdline.txt
+cat <<EOF > "${_BUILDDIR}"/root/boot/cmdline.txt
 dwc_otg.fiq_fix_enable=2 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext3 elevator=deadline fsck.repair=yes rootwait net.ifnames=0
 EOF
 
 #config.txt
 if [[ "$ARCH" == "arm64" ]]; then
   # Remove repeat conditional filters [all] in config.txt
-  cat <<EOF >> ${_BUILDDIR}/root/boot/config.txt
+  cat <<EOF >> "${_BUILDDIR}"/root/boot/config.txt
 [pi2]
 # Pi2 is 64-bit only on v1.2+
 # 64-bit kernel for Raspberry Pi 2 is called kernel8 (armv8a)
@@ -74,7 +74,7 @@ EOF
 fi
 
 #fstab
-cat <<EOF > ${_BUILDDIR}/root/etc/fstab
+cat <<EOF > "${_BUILDDIR}"/root/etc/fstab
 # <file system> <mount point>   <type>  <options>       <dump>  <pass>
 proc            /proc           proc    defaults          0       0
 /dev/mmcblk0p1  /boot           vfat    defaults          0       2


### PR DESCRIPTION
I ran spellcheck on the code base and fixed the following warnings:
- [SC2086](https://www.shellcheck.net/wiki/SC2086) - Double quote to prevent globbing and word splitting.
- [SC2006](https://www.shellcheck.net/wiki/SC2006) - Use $(...) notation instead of legacy backticked \`...\`.

This is a refactor, there is no functional change.